### PR TITLE
Use `data-turbo-*` and `Turbo.*` prefixes

### DIFF
--- a/docs/handbook/02_drive.md
+++ b/docs/handbook/02_drive.md
@@ -17,7 +17,7 @@ There are two types of visit: an _application visit_, which has an action of _ad
 
 ## Application Visits
 
-Application visits are initiated by clicking a Turbo Drive-enabled link, or programmatically by calling [`TurboDrive.visit(location)`](/reference/drive#turbodrivevisit).
+Application visits are initiated by clicking a Turbo Drive-enabled link, or programmatically by calling [`Turbo.visit(location)`](/reference/drive#turbodrivevisit).
 
 An application visit always issues a network request. When the response arrives, Turbo Drive renders its HTML and completes the visit.
 
@@ -37,16 +37,16 @@ Applications using the Turbo Drive [iOS adapter](https://github.com/hotwired/tur
 
 You may wish to visit a location without pushing a new history entry onto the stack. The _replace_ visit action uses [`history.replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) to discard the topmost history entry and replace it with the new location.
 
-To specify that following a link should trigger a replace visit, annotate the link with `data-turbo-drive-action="replace"`:
+To specify that following a link should trigger a replace visit, annotate the link with `data-turbo-action="replace"`:
 
 ```html
-<a href="/edit" data-turbo-drive-action="replace">Edit</a>
+<a href="/edit" data-turbo-action="replace">Edit</a>
 ```
 
-To programmatically visit a location with the replace action, pass the `action: "replace"` option to `TurboDrive.visit`:
+To programmatically visit a location with the replace action, pass the `action: "replace"` option to `Turbo.visit`:
 
 ```js
-TurboDrive.visit("/edit", { action: "replace" })
+Turbo.visit("/edit", { action: "replace" })
 ```
 
 Applications using the Turbo Drive [iOS adapter](https://github.com/hotwired/turbo-ios) typically handle replace visits by dismissing the topmost view controller and pushing a new view controller onto the navigation stack without animation.
@@ -61,11 +61,11 @@ If possible, Turbo Drive will render a copy of the page from cache without makin
 
 Turbo Drive saves the scroll position of each page before navigating away and automatically returns to this saved position on restoration visits.
 
-Restoration visits have an action of _restore_ and Turbo Drive reserves them for internal use. You should not attempt to annotate links or invoke `TurboDrive.visit` with an action of `restore`.
+Restoration visits have an action of _restore_ and Turbo Drive reserves them for internal use. You should not attempt to annotate links or invoke `Turbo.visit` with an action of `restore`.
 
 ## Canceling Visits Before They Start
 
-Application visits can be canceled before they start, regardless of whether they were initiated by a link click or a call to [`TurboDrive.visit`](/reference/drive#turbodrivevisit).
+Application visits can be canceled before they start, regardless of whether they were initiated by a link click or a call to [`Turbo.visit`](/reference/drive#turbodrivevisit).
 
 Listen for the `turbo-drive:before-visit` event to be notified when a visit is about to start, and use `event.data.url` (or `$event.originalEvent.data.url`, when using jQuery) to check the visit’s location. Then cancel the visit by calling `event.preventDefault()`.
 
@@ -73,21 +73,21 @@ Restoration visits cannot be canceled and do not fire `turbo-drive:before-visit`
 
 ## Disabling Turbo Drive on Specific Links
 
-Turbo Drive can be disabled on a per-link basis by annotating a link or any of its ancestors with `data-turbo-drive="false"`.
+Turbo Drive can be disabled on a per-link basis by annotating a link or any of its ancestors with `data-turbo="false"`.
 
 ```html
-<a href="/" data-turbo-drive="false">Disabled</a>
+<a href="/" data-turbo="false">Disabled</a>
 
-<div data-turbo-drive="false">
+<div data-turbo="false">
   <a href="/">Disabled</a>
 </div>
 ```
 
-To reenable when an ancestor has opted out, use `data-turbo-drive="true"`:
+To reenable when an ancestor has opted out, use `data-turbo="true"`:
 
 ```html
-<div data-turbo-drive="false">
-  <a href="/" data-turbo-drive="true">Enabled</a>
+<div data-turbo="false">
+  <a href="/" data-turbo="true">Enabled</a>
 </div>
 ```
 
@@ -97,7 +97,7 @@ Links with Turbo Drive disabled will be handled normally by the browser.
 
 During Turbo Drive navigation, the browser will not display its native progress indicator. Turbo Drive installs a CSS-based progress bar to provide feedback while issuing a request.
 
-The progress bar is enabled by default. It appears automatically for any page that takes longer than 500ms to load. (You can change this delay with the [`TurboDrive.setProgressBarDelay`](/reference/drive#turbodrivesetprogressbardelay) method.)
+The progress bar is enabled by default. It appears automatically for any page that takes longer than 500ms to load. (You can change this delay with the [`Turbo.setProgressBarDelay`](/reference/drive#turbodrivesetprogressbardelay) method.)
 
 The progress bar is a `<div>` element with the class name `turbo-drive-progress-bar`. Its default styles appear first in the document and can be overridden by rules that come later.
 
@@ -122,13 +122,13 @@ To disable the progress bar entirely, set its `visibility` style to `hidden`:
 
 Turbo Drive can track the URLs of asset elements in `<head>` from one page to the next and automatically issue a full reload if they change. This ensures that users always have the latest versions of your application’s scripts and styles.
 
-Annotate asset elements with `data-turbo-drive-track="reload"` and include a version identifier in your asset URLs. The identifier could be a number, a last-modified timestamp, or better, a digest of the asset’s contents, as in the following example.
+Annotate asset elements with `data-turbo-track="reload"` and include a version identifier in your asset URLs. The identifier could be a number, a last-modified timestamp, or better, a digest of the asset’s contents, as in the following example.
 
 ```html
 <head>
   ...
-  <link rel="stylesheet" href="/application-258e88d.css" data-turbo-drive-track="reload">
-  <script src="/application-cbd3cd4.js" data-turbo-drive-track="reload"></script>
+  <link rel="stylesheet" href="/application-258e88d.css" data-turbo-track="reload">
+  <script src="/application-cbd3cd4.js" data-turbo-track="reload"></script>
 </head>
 ```
 

--- a/docs/handbook/06_building.md
+++ b/docs/handbook/06_building.md
@@ -19,7 +19,7 @@ When you navigate to a new page, Turbolinks looks for any `<script>` elements in
 
 Turbolinks evaluates `<script>` elements in a page’s `<body>` each time it renders the page. You can use inline body scripts to set up per-page JavaScript state or bootstrap client-side models. To install behavior, or to perform more complex operations when the page changes, avoid script elements and use the `turbo-drive:load` event instead.
 
-Annotate `<script>` elements with `data-turbo-drive-eval="false"` if you do not want Turbo to evaluate them after rendering. Note that this annotation will not prevent your browser from evaluating scripts on the initial page load.
+Annotate `<script>` elements with `data-turbo-eval="false"` if you do not want Turbo to evaluate them after rendering. Note that this annotation will not prevent your browser from evaluating scripts on the initial page load.
 
 ### Loading Your Application’s JavaScript Bundle
 
@@ -56,10 +56,10 @@ document.addEventListener("turbo-drive:before-cache", function() {
 
 ### Detecting When a Preview is Visible
 
-Turbo Drive adds a `data-turbo-drive-preview` attribute to the `<html>` element when it displays a preview from cache. You can check for the presence of this attribute to selectively enable or disable behavior when a preview is visible.
+Turbo Drive adds a `data-turbo-preview` attribute to the `<html>` element when it displays a preview from cache. You can check for the presence of this attribute to selectively enable or disable behavior when a preview is visible.
 
 ```js
-if (document.documentElement.hasAttribute("data-turbo-drive-preview")) {
+if (document.documentElement.hasAttribute("data-turbo-preview")) {
   // Turbolinks is displaying a preview
 }
 ```
@@ -161,10 +161,10 @@ Consider a Turbo Drive application with a shopping cart. At the top of each page
 
 Now imagine a user who has navigated to several pages in this application. She adds an item to her cart, then presses the Back button in her browser. Upon navigation, Turbo Drive restores the previous page’s state from cache, and the cart item count erroneously changes from 1 to 0.
 
-You can avoid this problem by marking the counter element as permanent. Designate permanent elements by giving them an HTML `id` and annotating them with `data-turbo-drive-permanent`.
+You can avoid this problem by marking the counter element as permanent. Designate permanent elements by giving them an HTML `id` and annotating them with `data-turbo-permanent`.
 
 ```html
-<div id="cart-counter" data-turbo-drive-permanent>1 item</div>
+<div id="cart-counter" data-turbo-permanent>1 item</div>
 ```
 
 Before each render, Turbo Drive matches all permanent elements by `id` and transfers them from the original page to the new page, preserving their data and event listeners.

--- a/docs/reference/drive.md
+++ b/docs/reference/drive.md
@@ -6,43 +6,43 @@ description: "A reference of everything you can do with Turbo Drive."
 
 # Drive
 
-## TurboDrive.visit
+## Turbo.visit
 
 ```js
-TurboDrive.visit(location)
-TurboDrive.visit(location, { action: action })
+Turbo.visit(location)
+Turbo.visit(location, { action: action })
 ```
 
 Performs an [Application Visit](/handbook/drive#application-visits) to the given _location_ (a string containing a URL or path) with the specified _action_ (a string, either `"advance"` or `"replace"`).
 
-If _location_ is a cross-origin URL, or falls outside of the specified root (see [Setting a Root Location](/handbook/drive#setting-a-root-location)), or if the value of [`TurboDrive.supported`](#turbodrivesupported) is `false`, Turbolinks performs a full page load by setting `window.location`.
+If _location_ is a cross-origin URL, or falls outside of the specified root (see [Setting a Root Location](/handbook/drive#setting-a-root-location)), or if the value of [`Turbo.supported`](#turbodrivesupported) is `false`, Turbo performs a full page load by setting `window.location`.
 
 If _action_ is unspecified, Turbo Drive assumes a value of `"advance"`.
 
 Before performing the visit, Turbo Drive fires a `turbo-drive:before-visit` event on `document`. Your application can listen for this event and cancel the visit with `event.preventDefault()` (see [Canceling Visits Before They Start](/handbook/drive#canceling-visits-before-they-start)).
 
-## TurboDrive.clearCache
+## Turbo.clearCache
 
 ```js
-TurboDrive.clearCache()
+Turbo.clearCache()
 ```
 
 Removes all entries from the Turbo Drive page cache. Call this when state has changed on the server that may affect cached pages.
 
-## TurboDrive.setProgressBarDelay
+## Turbo.setProgressBarDelay
 
 ```js
-TurboDrive.setProgressBarDelay(delayInMilliseconds)
+Turbo.setProgressBarDelay(delayInMilliseconds)
 ```
 
 Sets the delay after which the [progress bar](/handbook/drive#displaying-progress) will appear during navigation, in milliseconds. The progress bar appears after 500ms by default.
 
 Note that this method has no effect when used with the iOS or Android adapters.
 
-## TurboDrive.supported
+## Turbo.supported
 
 ```js
-if (TurboDrive.supported) {
+if (Turbo.supported) {
   // ...
 }
 ```


### PR DESCRIPTION
Replace all references to `TurboDrive.` with `Turbo.`

Replace `data-turbo-drive-*` prefixed attributes with `data-turbo-*`.

[hotwired/turbo#2]: https://github.com/hotwired/turbo/pull/2
[comment]: https://github.com/hotwired/turbo/pull/2#issuecomment-744702305