### PR TITLE
Document submit-start and submit-end events

### DIFF
--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -6,24 +6,28 @@ description: "A reference of everything you can do with Turbo Events."
 
 # Events
 
-Turbo emits events that allow you to track the navigation lifecycle and respond to page loading. Except where noted, Turbo fires events on the `document` object.  
+Turbo emits events that allow you to track the navigation lifecycle and respond to page loading. Except where noted, Turbo fires events on the `document` object.
 
 (Note that when using jQuery, the data on the event must be accessed as `$event.originalEvent.data`.)
 
-* `turbo-drive:click` fires when you click a Turbo Drive-enabled link. The clicked element is the event target. Access the requested location with `event.data.url`. Cancel this event to let the click fall through to the browser as normal navigation.
+* `turbo:click` fires when you click a Turbo-enabled link. The clicked element is the event target. Access the requested location with `event.detail.url`. Cancel this event to let the click fall through to the browser as normal navigation.
 
-* `turbo-drive:before-visit` fires before visiting a location, except when navigating by history. Access the requested location with `event.data.url`. Cancel this event to prevent navigation.
+* `turbo:before-visit` fires before visiting a location, except when navigating by history. Access the requested location with `event.detail.url`. Cancel this event to prevent navigation.
 
-* `turbo-drive:visit` fires immediately after a visit starts.
+* `turbo:visit` fires immediately after a visit starts.
 
-* `turbo-drive:request-start` fires before Turbo Drive issues a network request to fetch the page. Access the XMLHttpRequest object with `event.data.xhr`.
+* `turbo:submit-start` fires during a form submission. Access the `FormSubmission` object with `event.detail.formSubmission`.
 
-* `turbo-drive:request-end` fires after the network request completes. Access the XMLHttpRequest object with `event.data.xhr`.
+* `turbo:before-fetch-request` fires before Turbo issues a network request to fetch the page. Access the fetch options object with `event.detail`.
 
-* `turbo-drive:before-cache` fires before Turbo Drive saves the current page to cache.
+* `turbo:before-fetch-response` fires after the network request completes. Access the fetch options object with `event.detail`.
 
-* `turbo-drive:before-render` fires before rendering the page. Access the new `<body>` element with `event.data.newBody`.
+* `turbo:submit-end` fires after the form submission-initiated network request completes. Access the `FormSubmission` object with `event.detail.formSubmission` along with `FormSubmissionResult` properties included within `event.detail`.
 
-* `turbo-drive:render` fires after Turbo Drive renders the page. This event fires twice during an application visit to a cached location: once after rendering the cached version, and again after rendering the fresh version.
+* `turbo:before-cache` fires before Turbo saves the current page to cache.
 
-* `turbo-drive:load` fires once after the initial page load, and again after every Turbo Drive visit. Access visit timing metrics with the `event.data.timing` object.
+* `turbo:before-render` fires before rendering the page. Access the new `<body>` element with `event.detail.newBody`.
+
+* `turbo:render` fires after Turbo renders the page. This event fires twice during an application visit to a cached location: once after rendering the cached version, and again after rendering the fresh version.
+
+* `turbo:load` fires once after the initial page load, and again after every Turbo visit. Access visit timing metrics with the `event.detail.timing` object.


### PR DESCRIPTION
Replace `turbo-drive:` event prefix with `turbo:`.

Replace "Turbo Drive" mentions with "Turbo".

Replace `request-start` with `before-fetch-request` and `request-end`
with `before-fetch-response`.

Document the `turbo:submit-start` and `turbo:submit-end` events which
fire during `<form>` element submissions.

Additionally, Turbo utilizes `CustomEvent` instances, which encode
custom data in the [CustomEvent.detail][] property _instead of
`event.data`. This commit documents that change.

[CustomEvent.detail]: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail

