### PR TITLE
Remove the word "simply"

### DIFF
--- a/docs/handbook/07_installing.md
+++ b/docs/handbook/07_installing.md
@@ -5,7 +5,7 @@ description: "Learn how to install Turbo in your application."
 
 # Installing Turbo in Your Application
 
-Turbo can either be installed in compiled form by simply referencing the Turbo distributable script directly in the `<head>` of your application or through npm via a bundler like Webpack.
+Turbo can either be installed in compiled form by referencing the Turbo distributable script directly in the `<head>` of your application or through npm via a bundler like Webpack.
 
 ## In Compiled Form
 


### PR DESCRIPTION
While the intention is to show that a step isn't difficult, using words like "simply" or "just" can have the opposite effect: making the reader feel bad if they don't find the instruction simple.

https://www.achrafkassioui.com/blog/simple/
https://bradfrost.com/blog/post/just/

Thank you so much for releasing Turbo (and documenting it)—great stuff!