### PR TITLE
Document the `before-stream-render` event

### DIFF
--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -28,6 +28,8 @@ Turbo emits events that allow you to track the navigation lifecycle and respond 
 
 * `turbo:before-render` fires before rendering the page. Access the new `<body>` element with `event.detail.newBody`.
 
+* `turbo:before-stream-render` fires before rendering a Turbo Stream page update.
+
 * `turbo:render` fires after Turbo renders the page. This event fires twice during an application visit to a cached location: once after rendering the cached version, and again after rendering the fresh version.
 
 * `turbo:load` fires once after the initial page load, and again after every Turbo visit. Access visit timing metrics with the `event.detail.timing` object.


### PR DESCRIPTION
Related to https://github.com/hotwired/turbo/issues/23.

Adds an entry for the [turbo:before-stream-render][] event.

[turbo:before-stream-render]: https://github.com/hotwired/turbo/blob/aae160bed764ca7322be1e3a9e00366787d96f7f/src/elements/stream_element.ts#L77