### PR TITLE
Make initial frame content useful

### DIFF
--- a/docs/handbook/03_frames.md
+++ b/docs/handbook/03_frames.md
@@ -74,11 +74,11 @@ In the example above, the trays start empty, but it's also possible to populate 
 
 ```html
 <turbo-frame id="set_aside_tray" src="/emails/set_aside">
-  <img src="/icons/spinner.gif">
+  <a href="/emails/set_aside">Set aside emails</a>
 </turbo-frame>
 ```
 
-Upon loading the imbox page, the set-aside tray is loaded from `/emails/set_aside`, and the response must contain a corresponding `<turbo-frame id="set_aside_tray">` element as in the original example:
+With some JavaScript, you could replace the link with a spinner when the content starts loading. Upon loading the imbox page, the set-aside tray is loaded from `/emails/set_aside`, and the response must contain a corresponding `<turbo-frame id="set_aside_tray">` element as in the original example:
 
 ```html
 <body>


### PR DESCRIPTION
If the JavaScript does not run for whatever reason, provide a link so that the set side emails can still be seen.

(I wondered also whether to include a reference to the before-visit event that could be used as a hook to show the spinner, but wasn't sure.)
