### PR TITLE
Fix Turbo Stream response Content-Type examples

### DIFF
--- a/docs/handbook/02_drive.md
+++ b/docs/handbook/02_drive.md
@@ -172,5 +172,5 @@ After a stateful request from a form submission, Turbo Drive expects the server 
 
 ## Streaming After a Form Submission
 
-Servers may also respond to form submissions with a [Turbo Streams](streams) message by sending the header `Content-Type: text/html; turbo-stream` followed by one or more `<turbo-stream>` elements in the response body. This lets you update multiple parts of the page without navigating.
+Servers may also respond to form submissions with a [Turbo Streams](streams) message by sending the header `Content-Type: text/html; turbo-stream=*` followed by one or more `<turbo-stream>` elements in the response body. This lets you update multiple parts of the page without navigating.
 <br><br>

--- a/docs/handbook/04_streams.md
+++ b/docs/handbook/04_streams.md
@@ -114,7 +114,7 @@ end
 When the form to create a new message submits to the `MessagesController#create` action, the very same partial template that was used to render the list of messages in `MessagesController#index` is used to render the turbo-stream action. This will come across as a response that looks like this:
 
 ```html
-Content-Type: text/html; turbo-stream; charset=utf-8
+Content-Type: text/html; turbo-stream=*; charset=utf-8
 
 <turbo-stream action="append" target="messages">
   <template>


### PR DESCRIPTION
Seems the standard MIME type format is `type/subtype;parameter=value`. I was working on an Express-based project, which uses [content-type](https://www.npmjs.com/package/content-type) to validate `Content-Type` header values, and using `text/html; turbo-steam; charset=utf-8` made Express throw invalid format error.

I wasn’t very familiar with MIME type format so it took me a while to fix this (after I found [this test file](https://github.com/hotwired/turbo/blob/aae160bed764ca7322be1e3a9e00366787d96f7f/src/tests/server.ts#L19) :). Thought it’d be more clear to have the valid MIME format in the docs.