### PR TITLE
Omit `formats: :html` option from Turbo Stream doc

### DIFF
--- a/docs/handbook/04_streams.md
+++ b/docs/handbook/04_streams.md
@@ -102,7 +102,7 @@ class MessagesController < ApplicationController
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: turbo_stream.append(:messages, partial: "messages/message",
-          locals: { message: message }, formats: :html)
+          locals: { message: message })
       end
 
       format.html { redirect_to messages_url }


### PR DESCRIPTION
Judging by the [Turbo::Streams::TagBuilder#action][] and
[Turbo::Streams::TagBuilder#render_record][] implementations, the Turbo
Stream documentation's mention of `formats: :html` is redundant, and can
be omitted.

[Turbo::Streams::TagBuilder#action]: https://github.com/hotwired/turbo-rails/blob/0a3fded56401a29b9dbcb65dc98c72ab73a7deba/app/models/turbo/streams/tag_builder.rb#L106
[Turbo::Streams::TagBuilder#render_record]: https://github.com/hotwired/turbo-rails/blob/0a3fded56401a29b9dbcb65dc98c72ab73a7deba/app/models/turbo/streams/tag_builder.rb#L124