### PR TITLE
add a brief intro for turbo frames

### DIFF
--- a/docs/handbook/03_frames.md
+++ b/docs/handbook/03_frames.md
@@ -5,7 +5,9 @@ description: "Turbo Frames decompose pages into independent contexts, which can 
 
 # Decompose with Turbo Frames
 
-Turbo Frames are created by wrapping a segment of the page in a `<turbo-frame>` element. Each element must have a unique ID, which is used to match the content being replaced when requesting new pages from the server. A single page can have multiple frames, each establishing their own context:
+Turbo Frames allow predefined parts of a page to be updated on request. Any links and forms inside a frame are captured, and the frame contents automatically updated after receiving a response. Regardless of whether the server provides a full document, or just a fragment containing an updated version of the requested frame, only that particular frame will be extracted from the response to replace the existing content.
+
+Frames are created by wrapping a segment of the page in a `<turbo-frame>` element. Each element must have a unique ID, which is used to match the content being replaced when requesting new pages from the server. A single page can have multiple frames, each establishing their own context:
 
 ```html
 <body>


### PR DESCRIPTION
The page for Turbo Frames does not actually have a brief conceptual introduction as the first paragraph (Drive/Streams do have that!). I think adding this can help people better understand the rest of the document, especially if they only skimmed what is written about Turbo Frames on the introduction page.