### PR TITLE
Fix npm package installing instruction

### DIFF
--- a/docs/handbook/07_installing.md
+++ b/docs/handbook/07_installing.md
@@ -16,7 +16,7 @@ You can download the latest distributable script from the GitHub releases page, 
 You can install Turbo from npm via the `npm` or `yarn` packaging tools. Then require or import that in your code:
 
 ```javascript
-import Turbo from "@hotwired/turbo"
+import * as Turbo from "@hotwired/turbo"
 ```
 
 ## In a Ruby on Rails application


### PR DESCRIPTION
Hi! I think I found a mistake in the documentation related to the installation of turbo through the npm.

At the moment, "Turbo" is not exported as "default" and such use will not work.
This patch fixes the documentation so that there is access for features.

Export happens [here]( https://github.com/hotwired/turbo/blob/d0f306efd5b518f8eb2251cae37dbf0e5ddac9f4/src/index.ts#L5) and turbo-rails already [uses](https://github.com/hotwired/turbo-rails/blob/a008cd0962998eb4da3fffdf1b3ababbe3321bdd/app/javascript/turbo/index.js#L3) correct syntax.