### PR TITLE
Add: link to site source code

### DIFF
--- a/_source/_data/site.json
+++ b/_source/_data/site.json
@@ -3,5 +3,6 @@
   "description": "The speed of a single-page web application without having to write any JavaScript.",
   "url": "https://turbo.hotwire.dev",
   "discourse_url": "https://discuss.hotwire.dev",
-  "github_url": "https://github.com/hotwired/turbo"
+  "github_url": "https://github.com/hotwired/turbo",
+  "turbo_site_github_url": "https://github.com/hotwired/turbo-site"
 }

--- a/_source/_includes/navigation.html
+++ b/_source/_includes/navigation.html
@@ -1,31 +1,27 @@
 <a class="nav-logo" href="/" aria-label="Turbo">
   {% include svg/turbo-logo.svg %}
 </a>
-
 <input type="checkbox" id="hamburger" class="nav-checkbox"/>
 <label class="nav-mobile-button" for="hamburger"><span></span> Menu</label>
-
 <nav class="nav">
-
   <label class="nav-mobile-button nav-mobile-button--close" for="hamburger"><span></span> close</label>
-
   <ul class="nav__list {% if type == "horizontal" %} nav__list--horizontal{% endif %}">
-    <li>
-      <a class="nav__list-link{% if section_title == "Handbook" %} active{% endif %}" href="/handbook/introduction">Handbook</a>
-
-      {% include section-nav.html, section: "handbook" %}
-    </li>
-    <li>
-      <a class="nav__list-link{% if section_title == "Reference" %} active{% endif %}" href="/reference/drive">Reference</a>
-
-      {% include section-nav.html, section: "reference" %}
-    </li>
-    <li>
-      <a class="nav__list-link" href="{{ site.discourse_url }}" title="Have a question? Connect with other developers on the Hotwire Discourse community forum.">Community</a>
-    </li>
-    <li>
-      <a class="nav__list-link" href="{{ site.github_url }}" title="Head over to GitHub for code, bug reports, and pull requests.">Source Code</a>
-    </li>
-  </ul>
-
+  <li>
+    <a class="nav__list-link{% if section_title == "Handbook" %} active{% endif %}" href="/handbook/introduction">Handbook</a>
+    {% include section-nav.html, section: "handbook" %}
+  </li>
+  <li>
+    <a class="nav__list-link{% if section_title == "Reference" %} active{% endif %}" href="/reference/drive">Reference</a>
+    {% include section-nav.html, section: "reference" %}
+  </li>
+  <li>
+    <a class="nav__list-link" href="{{ site.discourse_url }}" title="Have a question? Connect with other developers on the Hotwire Discourse community forum.">Community</a>
+  </li>
+  <li>
+    <a class="nav__list-link" href="{{ site.github_url }}" title="Head over to GitHub for code, bug reports, and pull requests.">Source Code</a>
+  </li>
+  <li>
+    <a class="nav__list-link" href="{{ site.turbo_site_github_url }}" title="Add or edit the site's documentation."> Site Source</a>
+  </li>
+</ul>
 </nav>


### PR DESCRIPTION
### What is this?

* Adds a link to the site source code.

### Why do we need it?

* To make it super easy for developers to make PRs on documentation. Right now, to find the site itself requires a little digging -- most developers might lose patience and might just let the errors/ommissions stand.

Feel free to close if it's not beneficial.