### PR TITLE
Document the use of the targets attribute in Turbo Stream tags

### DIFF
--- a/_source/handbook/04_streams.md
+++ b/_source/handbook/04_streams.md
@@ -70,13 +70,9 @@ Note that every `<turbo-stream>` element must wrap its included HTML inside a `<
 
 You can render any number of stream elements in a single stream message from a WebSocket, SSE or in response to a form submission.
 
-## Applying an Action on Multiple Targets
+## Actions With Multiple Targets
 
-Usually, a `<turbo-stream>` is meant to target a single element on your page. This is done with the `target` attribute. Under the hood, Turbo uses `getElementById` to select the target element and apply the action.
-
-For cases when you want to have a single `<turbo-stream>` apply to multiple elements at once, you may include a `targets` attribute instead of `target`. The value should be a CSS query selector. Turbo will call `querySelectorAll` and apply the action to all matching elements.
-
-Here are some examples of selecting multiple targets:
+Actions can be applied against multiple targets using the `targets` attribute with a CSS query selector, instead of the regular `target` attribute that uses a dom ID reference. Examples:
 
 ```html
 <turbo-stream action="remove" targets=".old_records">

--- a/_source/handbook/04_streams.md
+++ b/_source/handbook/04_streams.md
@@ -70,6 +70,29 @@ Note that every `<turbo-stream>` element must wrap its included HTML inside a `<
 
 You can render any number of stream elements in a single stream message from a WebSocket, SSE or in response to a form submission.
 
+## Applying an Action on Multiple Targets
+
+Usually, a `<turbo-stream>` is meant to target a single element on your page. This is done with the `target` attribute. Under the hood, Turbo uses `getElementById` to select the target element and apply the action.
+
+For cases when you want to have a single `<turbo-stream>` apply to multiple elements at once, you may include a `targets` attribute instead of `target`. The value should be a CSS query selector. Turbo will call `querySelectorAll` and apply the action to all matching elements.
+
+Here are some examples of selecting multiple targets:
+
+```html
+<turbo-stream action="remove" targets=".old_records">
+  <!-- The element with the class "old_records" will be removed.
+  The contents of this stream element are ignored. -->
+</turbo-stream>
+
+<turbo-stream action="after" targets="input.invalid_field">
+  <template>
+    <!-- The contents of this template will be added after the
+    all elements that match "inputs.invalid_field". -->
+    <span>Incorrect</span>
+  </template>
+</turbo-stream>
+```
+
 ## Streaming From HTTP Responses
 
 Turbo knows to automatically attach `<turbo-stream>` elements when they arrive in response to `<form>` submissions that declare a [MIME type][] of `text/vnd.turbo-stream.html`. When submitting a `<form>` element whose [method][] attribute is set to `POST`, `PUT`, `PATCH`, or `DELETE`, Turbo injects `text/vnd.turbo-stream.html` into the set of response formats in the request's [Accept][] header. When responding to requests containing that value in its [Accept][] header, servers can tailor their responses to deal with Turbo Streams, HTTP redirects, or other types of clients that don't support streams (such as native applications).

--- a/_source/reference/streams.md
+++ b/_source/reference/streams.md
@@ -82,7 +82,23 @@ Inserts the content within the template tag after the element designated by the 
 ```html
 <turbo-stream action="after" target="dom_id">
   <template>
-    Content to place before the element designated with the dom_id.
+    Content to place after the element designated with the dom_id.
+  </template>
+</turbo-stream>
+```
+
+## Targeting Multiple Elements
+
+For all actions, the `target` attribute is a dom id. To target multiple elements at once for a single `<turbo-stream>`
+tag, use a `targets` attribute instead with a CSS query selector.
+
+```html
+<turbo-stream action="remove" targets="css_query">
+</turbo-stream>
+
+<turbo-stream action="after" targets="css_query">
+  <template>
+    Content to place after the elements designated with the css_query.
   </template>
 </turbo-stream>
 ```

--- a/_source/reference/streams.md
+++ b/_source/reference/streams.md
@@ -89,16 +89,15 @@ Inserts the content within the template tag after the element designated by the 
 
 ## Targeting Multiple Elements
 
-For all actions, the `target` attribute is a dom id. To target multiple elements at once for a single `<turbo-stream>`
-tag, use a `targets` attribute instead with a CSS query selector.
+To target multiple elements with a single action, use the `targets` attribute with a CSS query selector instead of the `target` attribute.
 
 ```html
-<turbo-stream action="remove" targets="css_query">
+<turbo-stream action="remove" targets=".elementsWithClass">
 </turbo-stream>
 
-<turbo-stream action="after" targets="css_query">
+<turbo-stream action="after" targets=".elementsWithClass">
   <template>
-    Content to place after the elements designated with the css_query.
+    Content to place after the elements designated with the css query.
   </template>
 </turbo-stream>
 ```


### PR DESCRIPTION
This adds a mention to using `targets` with `<turbo-stream>` tags in the handbook and the reference pages.