### PR TITLE
Update reference/events documentation

### DIFF
--- a/_source/reference/events.md
+++ b/_source/reference/events.md
@@ -33,3 +33,7 @@ Turbo emits events that allow you to track the navigation lifecycle and respond 
 * `turbo:render` fires after Turbo renders the page. This event fires twice during an application visit to a cached location: once after rendering the cached version, and again after rendering the fresh version.
 
 * `turbo:load` fires once after the initial page load, and again after every Turbo visit. Access visit timing metrics with the `event.detail.timing` object.
+
+* `turbo:frame-render` fires right after `<turbo-frame>` element renders its view. The specific `<turbo-frame>` element is the event target. Access the `FetchResponse` object with `event.detail.fetchResponse` property.
+
+* `turbo:frame-load` fires when `<turbo-frame>` element is navigated and finishes loading (fires after `turbo:frame-render`). The specific `<turbo-frame>` element is the event target.


### PR DESCRIPTION
This PR updates the reference/events section by adding the following:

- Add 'turbo:frame-render' documentation (ref [#327](https://github.com/hotwired/turbo/pull/327))
- Add 'turbo:frame-load' documentation (ref [#59](https://github.com/hotwired/turbo/pull/59))