### PR TITLE
Add: link to site source - via github corner svg

### DIFF
--- a/_source/_data/site.json
+++ b/_source/_data/site.json
@@ -3,5 +3,6 @@
   "description": "The speed of a single-page web application without having to write any JavaScript.",
   "url": "https://turbo.hotwire.dev",
   "discourse_url": "https://discuss.hotwire.dev",
-  "github_url": "https://github.com/hotwired/turbo"
+  "github_url": "https://github.com/hotwired/turbo",
+  "turbo_site_github_main_branch_url": "https://github.com/hotwired/turbo-site/blob/main"
 }

--- a/_source/_includes/github-corner.html
+++ b/_source/_includes/github-corner.html
@@ -1,0 +1,11 @@
+<a href="{{site.turbo_site_github_main_branch_url}}/{{page.inputPath}}" class="github-corner" aria-label="View source on GitHub">
+	<svg width="30" height="30" viewBox="0 0 250 250" style="fill:#000000; color:#fff; transform: scale(-1, 1);" aria-hidden="true" class="github-corner">
+	<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+	<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm">
+	</path>
+	<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body">
+	</path>
+</svg>
+</a>
+<style>.github-corner{display: inline-block;} .github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>

--- a/_source/_includes/navigation.html
+++ b/_source/_includes/navigation.html
@@ -1,31 +1,27 @@
 <a class="nav-logo" href="/" aria-label="Turbo">
   {% include svg/turbo-logo.svg %}
 </a>
-
 <input type="checkbox" id="hamburger" class="nav-checkbox"/>
 <label class="nav-mobile-button" for="hamburger"><span></span> Menu</label>
-
 <nav class="nav">
-
   <label class="nav-mobile-button nav-mobile-button--close" for="hamburger"><span></span> close</label>
-
   <ul class="nav__list {% if type == "horizontal" %} nav__list--horizontal{% endif %}">
-    <li>
-      <a class="nav__list-link{% if section_title == "Handbook" %} active{% endif %}" href="/handbook/introduction">Handbook</a>
-
-      {% include section-nav.html, section: "handbook" %}
-    </li>
-    <li>
-      <a class="nav__list-link{% if section_title == "Reference" %} active{% endif %}" href="/reference/drive">Reference</a>
-
-      {% include section-nav.html, section: "reference" %}
-    </li>
-    <li>
-      <a class="nav__list-link" href="{{ site.discourse_url }}" title="Have a question? Connect with other developers on the Hotwire Discourse community forum.">Community</a>
-    </li>
-    <li>
-      <a class="nav__list-link" href="{{ site.github_url }}" title="Head over to GitHub for code, bug reports, and pull requests.">Source Code</a>
-    </li>
-  </ul>
-
+  <li>
+    <a class="nav__list-link{% if section_title == "Handbook" %} active{% endif %}" href="/handbook/introduction">Handbook</a>
+    {% include section-nav.html, section: "handbook" %}
+  </li>
+  <li>
+    <a class="nav__list-link{% if section_title == "Reference" %} active{% endif %}" href="/reference/drive">Reference</a>
+    {% include section-nav.html, section: "reference" %}
+  </li>
+  <li>
+    <a class="nav__list-link" href="{{ site.discourse_url }}" title="Have a question? Connect with other developers on the Hotwire Discourse community forum.">Community</a>
+  </li>
+  <li>
+    <a class="nav__list-link" href="{{ site.github_url }}" title="Head over to GitHub for code, bug reports, and pull requests.">Source Code</a>
+  </li>
+  <li>
+    <a class="nav__list-link" href="{{ site.turbo_site_github_url }}" title="Add or edit the site's documentation."> Site Source</a>
+  </li>
+</ul>
 </nav>

--- a/_source/_layouts/base.html
+++ b/_source/_layouts/base.html
@@ -3,12 +3,14 @@
 
   {% include head.html %}
 
-  <body>
-
+  <body>  	
     {% include jump.html %}
+
+  	{% include github-corner.html %}
 
     {{ content }}
 
   </body>
 
 </html>
+


### PR DESCRIPTION
### What is this?

* Adds a link to the site source code.

### Why do we need it?

* To make it easy for developers to make PRs on documentation. Right now, to find the site itself requires a little digging - i got super frustrated looking for it and this PR reflects that pain :)
* The link also the markdown page directly.

### Amendment to previous PR

* A  suggestion was made to put the link below the footer because the original PR made it too prominent: https://github.com/hotwired/turbo-site/pull/48#issuecomment-906171130
* I was lothe to do as suggested because I felt it would be too inconspicuous to be noticed. So I opted for a Github corner which makes it prominent, yet inconspicuous.
* The only negative that I can see is that there is a small gap when using mobile devices:

![image](https://user-images.githubusercontent.com/15097447/131207318-fdf83a9d-b89c-40d9-8144-1e2a1df85cda.png)



Github corners taken with thanks from this repo: https://github.com/tholman/github-corners