### PR TITLE
Document the method for terminating a form submission

### DIFF
--- a/_source/reference/events.md
+++ b/_source/reference/events.md
@@ -16,7 +16,7 @@ Turbo emits events that allow you to track the navigation lifecycle and respond 
 
 * `turbo:visit` fires immediately after a visit starts. Access the requested location with `event.detail.url` and action with `event.detail.action`.
 
-* `turbo:submit-start` fires during a form submission. Access the `FormSubmission` object with `event.detail.formSubmission`.
+* `turbo:submit-start` fires during a form submission. Access the `FormSubmission` object with `event.detail.formSubmission`. Abort form submission (e.g. after validation failure) with `event.detail.formSubmission.stop()`. (use `event.originalEvent.detail.formSubmission.stop()` if you're using jQuery).
 
 * `turbo:before-fetch-request` fires before Turbo issues a network request to fetch the page. Access the requested location with `event.detail.url` and the fetch options object with `event.detail.fetchOptions`. This event fires on the respective element (turbo-frame or form element) which triggers it and can be accessed with `event.target` property. Request can be canceled and continued with `event.detail.resume` (see [Pausing Requests](/handbook/drive#pausing-requests)).
 


### PR DESCRIPTION
This supports the pattern where form values are validated in javascript, and the form submission is aborted if validation fails. It works with the current code, but is not documented. I'm hoping that by making it part of the documented API, it can be relied upon not to change in future versions.