### PR TITLE
Clarify how to render the response of a GET form request

### DIFF
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -263,7 +263,9 @@ After a stateful request from a form submission, Turbo Drive expects the server 
 
 The exception to this rule is when the response is rendered with either a 4xx or 5xx status code. This allows form validation errors to be rendered by having the server respond with `422 Unprocessable Entity` and a broken server to display a "Something Went Wrong" screen on a `500 Internal Server Error`.
 
-The reason Turbo doesn't allow regular rendering on 200 is that browsers have built-in behavior for dealing with reloads on POST visits where they present a "Are you sure you want to submit this form again?" dialogue that Turbo can't replicate. Instead, Turbo will stay on the current URL upon a form submission that tries to render, rather than change it to the form action, since a reload would then issue a GET against that action URL, which may not even exist.
+The reason Turbo doesn't allow regular rendering on 200's from POST requests is that browsers have built-in behavior for dealing with reloads on POST visits where they present a "Are you sure you want to submit this form again?" dialogue that Turbo can't replicate. Instead, Turbo will stay on the current URL upon a form submission that tries to render, rather than change it to the form action, since a reload would then issue a GET against that action URL, which may not even exist.
+
+If the form submission is a GET request, you may render the directly rendered response by giving the form a `data-turbo-frame` target. If you'd like the URL to update as part of the rendering also pass a `data-turbo-action` attribute.
 
 ## Streaming After a Form Submission
 


### PR DESCRIPTION
After reading the docs at https://turbo.hotwired.dev/handbook/drive#redirecting-after-a-form-submission, I thought that it was not possible to render the results from a successful (200) form request unless the form did a redirect and GET. However, after reading https://github.com/hotwired/turbo/pull/398 I learned that you can replace the content and history with the results of a form request that is a GET request.

I may have misunderstood something here but I'd find it helpful to add a pointer to this technique in this section. I'm happy to edit this addition as necessary or move it to a better section if there is one. Thank you!