### PR TITLE
Fix unresponsive link in 04_streams.md

### DIFF
--- a/_source/handbook/04_streams.md
+++ b/_source/handbook/04_streams.md
@@ -5,7 +5,7 @@ description: "Turbo Streams deliver page changes over WebSocket, SSE or in respo
 
 # Come Alive with Turbo Streams
 
-Turbo Streams deliver page changes as fragments of HTML wrapped in self-executing `<turbo-stream>` elements. Each stream element specifies an action together with a target ID to declare what should happen to the HTML inside it. These elements are delivered by the server over a WebSocket, SSE or other transport to bring the application alive with updates made by other users or processes. A new email arriving in your <a href="https://itsnotatypo.com">imbox</a> is a great example.
+Turbo Streams deliver page changes as fragments of HTML wrapped in self-executing `<turbo-stream>` elements. Each stream element specifies an action together with a target ID to declare what should happen to the HTML inside it. These elements are delivered by the server over a WebSocket, SSE or other transport to bring the application alive with updates made by other users or processes. A new email arriving in your <a href="http://itsnotatypo.com">imbox</a> is a great example.
 
 ## Stream Messages and Actions
 


### PR DESCRIPTION
The itsnotatypo.com domain is used in an example linking back to the Imbox in HEY - but, it is unresponsive over HTTPS. Therefore, falling back to an unsecure protocol is a necessary evil we have to live with, if we are to defend the integrity of the Sacred Streams - with honor, glory, and my faithful iced tea.