### PR TITLE
Add documentation for data-turbo-preload

### DIFF
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -274,4 +274,12 @@ If the form submission is a GET request, you may render the directly rendered re
 ## Streaming After a Form Submission
 
 Servers may also respond to form submissions with a [Turbo Streams](streams) message by sending the header `Content-Type: text/vnd.turbo-stream.html` followed by one or more `<turbo-stream>` elements in the response body. This lets you update multiple parts of the page without navigating.
+
+## Preload Links Into the Cache
+
+Preload links into Turbo Drive's cache using `<a href="/" data-turbo-preload>Home</a>`.
+
+This will make page transitions feel lightning fast by providing a preview of a page even before the first visit. Use it to preload the most important pages in your application. Avoid over usage, as it will lead to loading content that is not needed.
+
+It also dovetails nicely with pages that leverage [Eager-Loading Frames](/reference/frames#eager-loaded-frame) or [Lazy-Loading Frames](/reference/frames#lazy-loaded-frame). As you can preload the structure of the page and show the user a meaningful loading state while the interesting content loads.
 <br><br>


### PR DESCRIPTION
This PR adds the documentation for https://github.com/hotwired/turbo/pull/552. Feedback on the documentation is of course welcome!

It appears the plan for the release of the feature is in 7.2 - https://github.com/hotwired/turbo/pull/552#issuecomment-1160493227. I could not see any 7.2 so I am not positive what would be the correct base branch to use here, so in lieu I have assigned main branch.

Here is a screenshot of the changes in development.

![image](https://user-images.githubusercontent.com/12163506/174831903-97b0f629-7ab9-4467-8fb2-87c47d83d6ab.png)
![image](https://user-images.githubusercontent.com/12163506/174831970-fc83cbee-eb12-4875-977c-4ca8e44c6004.png)
