### PR TITLE
Document `data-turbo-stream` attribute

### DIFF
--- a/_source/handbook/04_streams.md
+++ b/_source/handbook/04_streams.md
@@ -113,6 +113,8 @@ def destroy
 end
 ```
 
+By default, Turbo doesn't add the `text/vnd.turbo-stream.html` MIME type when submitting links, or forms with a method type of `GET`. To use Turbo Streams responses with `GET` requests in an application you can instruct Turbo to include the MIME type by adding a `data-turbo-stream` attribute to a link or form.
+
 [MIME type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
 [method]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-method
 [Accept]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept

--- a/_source/reference/attributes.md
+++ b/_source/reference/attributes.md
@@ -19,6 +19,7 @@ The following data attributes can be applied to elements to customize Turbo's be
 * `data-turbo-cache="false"` removes the element before the document is cached, preventing it from reappearing on restoration Visits.
 * `data-turbo-eval="false"` prevents inline `script` elements from being re-evaluated on Visits.
 * `data-turbo-method` changes the link request type from the default `GET`. Ideally, non-`GET` requests should be triggered with forms, but `data-turbo-method` might be useful where a form is not possible.
+* `data-turbo-stream` specifies that a link or form can accept a Turbo Streams response. Turbo [automatically requests stream responses](/handbook/streams#streaming-from-http-responses) for form submissions with non-`GET` methods; `data-turbo-stream` allows Turbo Streams to be used with `GET` requests as well.
 * `data-turbo-confirm` presents a confirm dialog with the given value. Can be used on `form` elements or links with `data-turbo-method`.
 
 ## Automatically Added Attributes


### PR DESCRIPTION
Documents the `data-turbo-stream` attribute introduced in https://github.com/hotwired/turbo/pull/612.