### PR TITLE
Bigger warning about `data-turbo: false`

### DIFF
--- a/_source/reference/attributes.md
+++ b/_source/reference/attributes.md
@@ -11,7 +11,7 @@ description: "A reference of everything you can do with element attributes and m
 
 The following data attributes can be applied to elements to customize Turbo's behaviour.
 
-* `data-turbo="false"` disables Turbo Drive on links and forms including descendants. To reenable when an ancestor has opted out, use `data-turbo="true"`. Use with caution as this can impact Back button behavior.
+* `data-turbo="false"` disables Turbo Drive on links and forms including descendants. To reenable when an ancestor has opted out, use `data-turbo="true"`. Be careful: when Turbo Drive is disabled, browsers treat link clicks as normal, but [native adapters](/handbook/native) may exit the app.
 * `data-turbo-track="reload"` tracks the element's HTML and performs a full page reload when it changes. Typically used to [keep `script` and CSS `link` elements up-to-date](/handbook/drive#reloading-when-assets-change).
 * `data-turbo-frame` identifies the Turbo Frame to navigate. Refer to the [Frames documentation](/reference/frames) for further details.
 * `data-turbo-action` customizes the [Visit](/handbook/drive#page-navigation-basics) action. Valid values are `replace` or `advance`. Can also be used with Turbo Frames to [promote frame navigations to page visits](/handbook/frames#promoting-a-frame-navigation-to-a-page-visit).


### PR DESCRIPTION
If you're using a native adapter then the default behavior on `data-turbo=false` will be to exit out of your app and try and open the link in the browser.

I think this behavior warrants a reasonable warning. I'm often reminding people of this on code reviews 😆