### PR TITLE
Document `Turbo.cache`

### DIFF
--- a/_source/handbook/06_building.md
+++ b/_source/handbook/06_building.md
@@ -83,6 +83,26 @@ To specify that a page should not be cached at all, use the `no-cache` directive
 
 To completely disable caching in your application, ensure every page contains a no-cache directive.
 
+### Opting Out of Caching from the client-side
+
+The value of the `<meta name="turbo-cache-control">` element can also be controlled by a client-side API exposed via `Turbo.cache`.
+
+```js
+// Set cache control of current page to `no-cache`
+Turbo.cache.exemptPageFromCache()
+
+// Set cache control of current page to `no-preview`
+Turbo.cache.exemptPageFromPreview()
+```
+
+Both functions will create a `<meta name="turbo-cache-control">` element in the `<head>` if the element is not already present.
+
+A previously set cache control value can be reset via:
+
+```js
+Turbo.cache.resetCacheControl()
+```
+
 ## Installing JavaScript Behavior
 
 You may be used to installing JavaScript behavior in response to the `window.onload`, `DOMContentLoaded`, or jQuery `ready` events. With Turbo, these events will fire only in response to the initial page load, not after any subsequent page changes. We compare two strategies for connecting JavaScript behavior to the DOM below.

--- a/_source/reference/drive.md
+++ b/_source/reference/drive.md
@@ -21,13 +21,15 @@ If _action_ is unspecified, Turbo Drive assumes a value of `"advance"`.
 
 Before performing the visit, Turbo Drive fires a `turbo:before-visit` event on `document`. Your application can listen for this event and cancel the visit with `event.preventDefault()` (see [Canceling Visits Before They Start](/handbook/drive#canceling-visits-before-they-start)).
 
-## Turbo.clearCache
+## Turbo.cache.clear
 
 ```js
-Turbo.clearCache()
+Turbo.cache.clear()
 ```
 
 Removes all entries from the Turbo Drive page cache. Call this when state has changed on the server that may affect cached pages.
+
+**Note:** This function was previously exposed as `Turbo.clearCache()`. The top-level function was deprecated in favor of the new `Turbo.cache.clear()` function.
 
 ## Turbo.setProgressBarDelay
 


### PR DESCRIPTION
Adds documentation for: 
- `Turbo.cache.clear()`
- `Turbo.cache.exemptPageFromCache()`
- `Turbo.cache.exemptPageFromPreview()`
- `Turbo.cache.resetCacheControl()`

See: https://github.com/hotwired/turbo/pull/632 and https://github.com/hotwired/turbo/pull/634

Relevant changes on the Deploy Preview:
- https://deploy-preview-106--epic-fermat-9d85e9.netlify.app/reference/drive#turbo.cache.clear
- https://deploy-preview-106--epic-fermat-9d85e9.netlify.app/handbook/building#opting-out-of-caching-from-the-client-side