### PR TITLE
Use `@hotwired/stimulus` package name for Stimulus example

### DIFF
--- a/_source/handbook/06_building.md
+++ b/_source/handbook/06_building.md
@@ -126,7 +126,7 @@ Implement a compatible controller and Stimulus connects it automatically:
 
 ```js
 // hello_controller.js
-import { Controller } from "stimulus"
+import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   greet() {


### PR DESCRIPTION
`@hotwired/stimulus` is the new recommended package name to use Stimulus. This PR updates the Stimulus example to import from the new package name.