### PR TITLE
Fix typo in `Turbo.setConfirmMethod` documentation

### DIFF
--- a/_source/reference/drive.md
+++ b/_source/reference/drive.md
@@ -41,7 +41,7 @@ Sets the delay after which the [progress bar](/handbook/drive#displaying-progres
 
 Note that this method has no effect when used with the iOS or Android adapters.
 
-## Turbo.setProgressBarDelay
+## Turbo.setConfirmMethod
 
 ```js
 Turbo.setConfirmMethod(confirmMethod)


### PR DESCRIPTION
Fixed typo in `Turbo.setConfirmMethod` documentation.