### PR TITLE
Document the `turbo:frame-missing` event

### DIFF
--- a/_source/reference/events.md
+++ b/_source/reference/events.md
@@ -34,8 +34,10 @@ Turbo emits events that allow you to track the navigation lifecycle and respond 
 
 * `turbo:load` fires once after the initial page load, and again after every Turbo visit. Access visit timing metrics with the `event.detail.timing` object.
 
-* `turbo:frame-render` fires right after `<turbo-frame>` element renders its view. The specific `<turbo-frame>` element is the event target. Access the `FetchResponse` object with `event.detail.fetchResponse` property.
+* `turbo:frame-render` fires right after a `<turbo-frame>` element renders its view. The specific `<turbo-frame>` element is the event target. Access the `FetchResponse` object with `event.detail.fetchResponse` property.
 
-* `turbo:frame-load` fires when `<turbo-frame>` element is navigated and finishes loading (fires after `turbo:frame-render`). The specific `<turbo-frame>` element is the event target.
+* `turbo:frame-load` fires when a `<turbo-frame>` element is navigated and finishes loading (fires after `turbo:frame-render`). The specific `<turbo-frame>` element is the event target.
+
+* `turbo:frame-missing` fires when a navigated `<turbo-frame>` element is unable to update its contents from a `<turbo-frame>` element in the response with a matching `[id]` attribute. After dispatching the event, Turbo transforms the response into a Visit and navigates the page. Cancel the event to prevent navigation. Access the request's [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) instance with `event.detail.response`.
 
 * `turbo:fetch-request-error` fires when a form or frame fetch request fails due to network errors. This event fires on the respective element (turbo-frame or form element) which triggers it and can be accessed with `event.target` property. This event can be canceled.


### PR DESCRIPTION
Describe the circumstances for dispatching a `turbo:frame-missing` event, along with how to add special-case handling.

Additionally, add missing `a` articles to two other event documentation bullet points.