### PR TITLE
Add childrenOnly to morphdom custom Frame renderer

### DIFF
--- a/_source/handbook/03_frames.md
+++ b/_source/handbook/03_frames.md
@@ -232,7 +232,7 @@ import morphdom from "morphdom"
 
 addEventListener("turbo:before-frame-render", (event) => {
   event.detail.render = (currentElement, newElement) => {
-    morphdom(currentElement, newElement)
+    morphdom(currentElement, newElement, { childrenOnly: true })
   }
 })
 ```


### PR DESCRIPTION
Hello! I noticed I couldn't reliably get to work the example in the [Custom Rendering section](https://turbo.hotwired.dev/handbook/frames#custom-rendering) of the Turbo Frame Handbook (I was randomly hitting `attr is undefined` [here](https://github.com/patrick-steele-idem/morphdom/blob/84f28d0438f432cdef8cd869cd67ab916c029f2e/dist/morphdom-esm.js#L19)). 

I fixed it by adding the `{ childrenOnly: true }` parameter to `morphdom()` which makes sense to me as Turbo itself replaces only the _content_ of the `<turbo-frame>` tag, not the tag itself. So, I'm proposing an update of the example in the docs.  Thanks!