### PR TITLE
Fix example for declaring custom actions on `StreamActions`

### DIFF
--- a/_source/handbook/04_streams.md
+++ b/_source/handbook/04_streams.md
@@ -209,15 +209,15 @@ addEventListener("turbo:before-stream-render", ((event) => {
 ```
 
 In addition to listening for `turbo:before-stream-render` events, applications
-can also declare actions as properties directly on `TurboStreamAction`:
+can also declare actions as properties directly on `StreamActions`:
 
 ```javascript
-import { TurboStreamActions } from "@hotwired/turbo"
+import { StreamActions } from "@hotwired/turbo"
 
 // <turbo-stream action="log" message="Hello, world"></turbo-stream>
 //
-TurboStreamActions.log = function (streamElement) {
-  console.log(streamElement.getAttribute("message"))
+StreamActions.log = function () {
+  console.log(this.getAttribute("message"))
 }
 ```
 


### PR DESCRIPTION
In https://github.com/hotwired/turbo/issues/881 @bennadel noticed that the examples for declaring custom stream actions in the docs aren't right.

This pull request fixes this by using `Turbo.StreamActions` instead of `TurboStreamActions`. It also removes the `streamElement` argument since that isn't necessary in plain JavaScript.