### PR TITLE
Mention Rails in more places

### DIFF
--- a/_source/handbook/01_introduction.md
+++ b/_source/handbook/01_introduction.md
@@ -110,5 +110,7 @@ See the <a href="https://github.com/hotwired/turbo-ios">Turbo Native: iOS</a> an
 
 ## Integrate with backend frameworks
 
-You don't need any backend framework to use Turbo. All the features are built to be used directly, without further abstractions. But if you have the opportunity to use a backend framework that's integrated with Turbo, you'll find life a lot simpler. [We've created a reference implementation for such an integration for Ruby on Rails](https://github.com/hotwired/turbo-rails).
+You don't need any backend framework to use Turbo. All the features are built to be used directly, without further abstractions. But if you have the opportunity to use a backend framework that's integrated with Turbo, you'll find life a lot simpler.
+
+[Learn more about installing Turbo into your application](./installing), or check out the [turbo-rails gem](https://github.com/hotwired/turbo-rails) if you are using Ruby on Rails.
 

--- a/_source/handbook/07_installing.md
+++ b/_source/handbook/07_installing.md
@@ -7,9 +7,13 @@ description: "Learn how to install Turbo in your application."
 
 Turbo can either be installed in compiled form by referencing the Turbo distributable script directly in the `<head>` of your application or through npm via a bundler like Webpack.
 
+## In a Ruby on Rails application
+
+Turbo is included by default in new Rails apps, when using Rails 7 or newer. You can also add it to an app using the [the turbo-rails gem](https://github.com/hotwired/turbo-rails).
+
 ## In Compiled Form
 
-You can download the latest distributable script from the GitHub releases page, then reference that in your `<script>` tag on your page. Or you can float on the latest release of Turbo using a CDN bundler like Skypack. See <a href="https://cdn.skypack.dev/@hotwired/turbo">https://cdn.skypack.dev/@hotwired/turbo</a> for more details.
+You can download the latest distributable script from the [GitHub releases page](https://github.com/hotwired/turbo/releases), then reference that in your `<script>` tag on your page. Or you can float on the latest release of Turbo using a CDN bundler like Skypack. See <a href="https://cdn.skypack.dev/@hotwired/turbo">https://cdn.skypack.dev/@hotwired/turbo</a> for more details.
 
 ## As An npm Package
 
@@ -18,7 +22,3 @@ You can install Turbo from npm via the `npm` or `yarn` packaging tools. Then req
 ```javascript
 import * as Turbo from "@hotwired/turbo"
 ```
-
-## In a Ruby on Rails application
-
-The Turbo JavaScript framework is included with [the turbo-rails gem](https://github.com/hotwired/turbo-rails) for direct use with the asset pipeline.

--- a/_source/index.html
+++ b/_source/index.html
@@ -24,14 +24,18 @@ layout: default
   </p>
 
   <ul>
-    <li><em>Turbo Drive</em> accelerates links and form submissions by negating the need for full page reloads.</li>
-    <li><em>Turbo Frames</em> decompose pages into independent contexts, which scope navigation and can be lazily loaded.</li>
-    <li><em>Turbo Streams</em> deliver page changes over WebSocket, SSE or in response to form submissions using just HTML and a set of CRUD-like actions.</li>
-    <li><em>Turbo Native</em> lets your <a href="https://m.signalvnoise.com/the-majestic-monolith/">majestic monolith</a> form the center of your native iOS and Android apps, with seamless transitions between web and native sections.</li>
+    <li><a href="/handbook/drive"><em>Turbo Drive</em></a> accelerates links and form submissions by negating the need for full page reloads.</li>
+    <li><a href="/handbook/frames"><em>Turbo Frames</em></a> decompose pages into independent contexts, which scope navigation and can be lazily loaded.</li>
+    <li><a href="/handbook/streams"><em>Turbo Streams</em></a> deliver page changes over WebSocket, SSE or in response to form submissions using just HTML and a set of CRUD-like actions.</li>
+    <li><a href="/handbook/native"><em>Turbo Native</em></a> lets your <a href="https://m.signalvnoise.com/the-majestic-monolith/">majestic monolith</a> form the center of your native iOS and Android apps, with seamless transitions between web and native sections.</li>
   </ul>
 
   <p>
     It's all done by sending HTML over the wire. And for those instances when that's not enough, you can reach for the other side of <a href="https://hotwired.dev">Hotwire</a>, and finish the job with <a href="https://stimulus.hotwired.dev">Stimulus</a>.
+  </p>
+
+  <p>
+    Turbo comes built in with <a href="https://rubyonrails.org/" target="_blank">Rails</a>, but it works with any server-side app framework.
   </p>
 
   <p style="text-align: center">


### PR DESCRIPTION
[This tweet](https://twitter.com/bradgessler/status/1630655623192002560) is good feedback, that if you're getting started it could be more clear how Turbo works with Rails. This PR makes some minor tweaks to the site to mention Rails in a few more places and give it more weight. While you _can_ use Turbo without Rails or with other frameworks, the reality is the overwhelming majority of users will use it with Rails.

If we want to go deeper on this idea, a page called "Using Turbo with Rails" might be a good next step. It would re-state a lot of https://github.com/hotwired/turbo-rails but I think it would not be a bad thing to have all those docs in one place. Happy to prepare another PR for this if there's appetite.