### PR TITLE
Slight change to Turbo Streams' description

### DIFF
--- a/_source/index.html
+++ b/_source/index.html
@@ -26,7 +26,7 @@ layout: default
   <ul>
     <li><em>Turbo Drive</em> accelerates links and form submissions by negating the need for full page reloads.</li>
     <li><em>Turbo Frames</em> decompose pages into independent contexts, which scope navigation and can be lazily loaded.</li>
-    <li><em>Turbo Streams</em> deliver page changes over WebSocket, SSE or in response to form submissions using just HTML and a set of CRUD-like actions.</li>
+    <li><em>Turbo Streams</em> define page changes using just HTML and a set of CRUD-like actions delivered by HTTP response, Server-sent Event or WebSocket connection.</li>
     <li><em>Turbo Native</em> lets your <a href="https://m.signalvnoise.com/the-majestic-monolith/">majestic monolith</a> form the center of your native iOS and Android apps, with seamless transitions between web and native sections.</li>
   </ul>
 


### PR DESCRIPTION
Inspired by [hotwired/turbo#580](https://github.com/hotwired/turbo/issues/580)

### Proposal

Modify Turbo Steams' bullet description to hopefully alleviate the false assumptions that Turbo Steams need to be delivered exclusively via WebSocket.  As developers we tend to skim documentation so I'm hoping a copy change might highlight the fact that we can also leverage traditional HTTP requests and responses (as well as SSEs).  The original copy certainly lists the various delivery methods but I suspect if we visually distance "Turbo Streams" and "WebSocket" a bit we may keep the reader for stopping at that point in the description, "_Got it! Steams -> Sockets cool!  Next_"

I'm happy to make any suggested copy changes and really just wanted to provide this as a starting point