### PR TITLE
Remove disclaimer for `data-turbo-method` not working in forms

### DIFF
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -134,9 +134,7 @@ By default, link clicks send a `GET` request to your server. But you can change 
 <a href="/articles/54" data-turbo-method="delete">Delete the article</a>
 ```
 
-The link will get converted into a hidden form next to the `a` element in the DOM. This means that the link can't appear inside another form, as you can't have nested forms.
-
-You should also consider that for accessibility reasons, it's better to use actual forms and buttons for anything that's not a GET.
+You should consider that for accessibility reasons, it's better to use actual forms and buttons for anything that's not a GET.
 
 ## Requiring Confirmation for a Visit
 


### PR DESCRIPTION
The [Turbo handbook mentions that `data-turbo-method`](https://turbo.hotwired.dev/handbook/drive#performing-visits-with-a-different-method) does not work in forms as it generates a hidden form which is invalid HTML.

While [working on a separate Rails PR](https://github.com/rails/rails/pull/47505), I discovered that when the `data-turbo-method` attribute is present, `turbo` actually appends the hidden form to `document.body` instead of nesting it in the parent form which makes it "work":

https://github.com/hotwired/turbo/blob/main/src/observers/form_link_click_observer.ts#L63

It doesn't feel right to have a non-`GET` link in a form. But, I also think it makes sense to remove the disclaimer as it's not accurate.

Please correct me or close this PR if I understood the `data-turbo-method` implementation wrongly. Thank you!