### PR TITLE
Replace reference to Skypack with jsDelivr

### DIFF
--- a/_source/handbook/07_installing.md
+++ b/_source/handbook/07_installing.md
@@ -9,7 +9,15 @@ Turbo can either be referenced in compiled form via the Turbo distributable scri
 
 ## In Compiled Form
 
-You can float on the latest release of Turbo using a CDN bundler like Skypack. See <a href="https://www.skypack.dev/view/@hotwired/turbo">https://www.skypack.dev/view/@hotwired/turbo</a> for more details. Or <a href="https://unpkg.com/browse/@hotwired/turbo@latest/dist/">download the compiled packages from unpkg</a>.
+You can float on the latest release of Turbo using a CDN bundler like jsDelivr. Just include a `<script>` tag in the `<head>` of your application:
+
+```html
+<head>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@hotwired/turbo@latest/dist/turbo.es2017-esm.min.js"></script>
+</head>
+```
+
+Or <a href="https://unpkg.com/browse/@hotwired/turbo@latest/dist/">download the compiled packages from unpkg</a>.
 
 ## As An npm Package
 


### PR DESCRIPTION
Skypack fails to compile packages that use private class fields, even though they are already supported by all major browsers and node. jsDelivr is convenient in that it provides automatically minified versions of the dist files.

Ref.

https://caniuse.com/mdn-javascript_classes_private_class_fields

https://github.com/skypackjs/skypack-cdn/issues/308 
https://github.com/skypackjs/skypack-cdn/issues/222 
https://github.com/skypackjs/skypack-cdn/issues/351 
https://github.com/skypackjs/skypack-cdn/issues/354