### PR TITLE
Add `[id]` to `<turbo-frame>` in Promotion example

### DIFF
--- a/_source/handbook/03_frames.md
+++ b/_source/handbook/03_frames.md
@@ -195,7 +195,7 @@ For example, consider a Frame that renders a paginated list of articles and
 transforms navigations into ["advance" Actions][advance]:
 
 ```html
-<turbo-frame data-turbo-action="advance">
+<turbo-frame id="articles" data-turbo-action="advance">
   <a href="/articles?page=2" rel="next">Next page</a>
 </turbo-frame>
 ```


### PR DESCRIPTION
Related to [hotwired/turbo-rails#560][]

All `<turbo-frame>` elements require an `[id]` attribute to navigate. This example is missing an `[id]`, so if the code were to be copy-pasted into an application with the `/articles` route, it wouldn't work as described.

[hotwired/turbo-rails#560]: https://github.com/hotwired/turbo-rails/issues/560