### PR TITLE
Escape pipe (`|`) character in Markdown

### DIFF
--- a/_source/reference/events.md
+++ b/_source/reference/events.md
@@ -200,7 +200,7 @@ Fires when the response to a `<turbo-frame>` element request does not contain a 
 | `event.detail` property   | Type                                                                  | Description
 |---------------------------|-----------------------------------------------------------------------|------------
 | `response`                | [Response][]                                                          | the HTTP response for the request initiated by a `<turbo-frame>` element
-| `visit`                   | `async (location: string | URL, visitOptions: VisitOptions) => void`  | a convenience function to initiate a page-wide navigation
+| `visit`                   | `async (location: string \| URL, visitOptions: VisitOptions) => void` | a convenience function to initiate a page-wide navigation
 
 [Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [Turbo.visit]: /reference/drive#turbo.visit


### PR DESCRIPTION
Follow-up to [#145][]

Escape a `|` operator to avoid Markdown's confusion about whether or not its a cell separator to a character.

![Screenshot 2024-02-13 at 11 43 30 AM](https://github.com/hotwired/turbo-site/assets/2575027/1f0ea4a6-d329-4ca2-b8d1-2b9a0c02d917)



[#145]: https://github.com/hotwired/turbo-site/pull/145