### PR TITLE
Clarify what refresh="morph" does on turbo-frames & correct the examples

### DIFF
--- a/_source/handbook/03_page_refreshes.md
+++ b/_source/handbook/03_page_refreshes.md
@@ -52,8 +52,7 @@ Sometimes, you want to ignore certain elements while morphing. For example, you 
 You can use [turbo frames](/handbook/frames.html) to define regions in your screen that will get reloaded using morphing when a page refresh happens. To do so, you must flag those frames with `refresh="morph"`.
 
 ```html
-<turbo-frame id="my-frame" refresh="morph">
-  ...
+<turbo-frame id="my-frame" refresh="morph" src="/my_frame">
 </turbo-frame>
 ```
 

--- a/_source/reference/frames.md
+++ b/_source/reference/frames.md
@@ -87,7 +87,7 @@ Like an eager-loaded frame, but the content is not loaded from `src` until the f
 </turbo-frame>
 ```
 
-## Frame that will get reloaded with morphing during page refreshes & when they are reloaded
+## Frame that will get reloaded with morphing during page refreshes & when they are explicitly reloaded with .reload()
 
 ```html
 <turbo-frame id="my-frame" refresh="morph" src="/my_frame">

--- a/_source/reference/frames.md
+++ b/_source/reference/frames.md
@@ -90,7 +90,7 @@ Like an eager-loaded frame, but the content is not loaded from `src` until the f
 ## Frame that will get reloaded with morphing during page refreshes & when they are reloaded
 
 ```html
-<turbo-frame id="my-frame" refresh="morph"/my_frame">
+<turbo-frame id="my-frame" refresh="morph" src="/my_frame">
 </turbo-frame>
 ```
 

--- a/_source/reference/frames.md
+++ b/_source/reference/frames.md
@@ -87,11 +87,10 @@ Like an eager-loaded frame, but the content is not loaded from `src` until the f
 </turbo-frame>
 ```
 
-## Frame that will get reloaded with morphing during page refreshes
+## Frame that will get reloaded with morphing during page refreshes & when they are reloaded
 
 ```html
-<turbo-frame id="my-frame" refresh="morph">
-  ...
+<turbo-frame id="my-frame" refresh="morph"/my_frame">
 </turbo-frame>
 ```
 


### PR DESCRIPTION
Update the two examples of `turbo-frame` with `refresh="morph"` so they are correct. This relates to PR https://github.com/hotwired/turbo/pull/1192 but it can be merged in without it since the clarifications are correct regardless of this other PR.