### PR TITLE
Document `turbo-prefetch` meta tags

### DIFF
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -338,7 +338,15 @@ InstantClick is enabled by default since Turbo v8, but you can disable it by add
 <meta name="turbo-prefetch" content="false">
 ```
 
-To avoid prefetching links that the user is briefly hovering, Turbo waits 100ms after the user hovers over the link before prefetching it. But you may want to disable the prefetching behavior on certain links leading to pages with expensive rendering.
+To avoid prefetching links that the user is briefly hovering, Turbo waits 100 milliseconds after the user hovers over the link before prefetching it. But you may want to disable the prefetching behavior on certain links leading to pages with expensive rendering.
+
+By default Turbo will cache requests for 10 seconds. Once that 10 seconds has passed, the value will expire, be cleared from the cache, and a new request will be issued on the next hover.
+
+You can configure this duration by adding this meta tag to your page:
+
+```html
+<meta name="turbo-prefetch-cache-time" content="15000">
+```
 
 You can disable the behavior on a per-element basis by annotating the element or any of its ancestors with `data-turbo-prefetch="false"`.
 

--- a/_source/reference/attributes.md
+++ b/_source/reference/attributes.md
@@ -43,3 +43,5 @@ The following `meta` elements, added to the `head`, can be used to customize cac
 * `<meta name="view-transition" content="same-origin">` to trigger view transitions on browsers that support the [View Transition API](https://caniuse.com/view-transitions).
 * `<meta name="turbo-refresh-method" content="morph">` will configure [page refreshes with morphing](/handbook/page_refreshes.html).
 * `<meta name="turbo-refresh-scroll" content="preserve">` will enable [scroll preservation during page refreshes](/handbook/page_refreshes.html).
+* `<meta name="turbo-prefetch" content="false">` will [opt-out of InstantClick prefetching](/handbook/drive#instantclick) for the entire page.
+* `<meta name="turbo-prefetch-cache-time" content="15000">` configures the time to live in milliseconds for an entry in the InstantClick prefetch cache. When omitted, the default value is 10 seconds.


### PR DESCRIPTION
* `<meta name="turbo-prefetch" content="false">` will opt-out of InstantClick prefetching for the entire page.

* `<meta name="turbo-prefetch-cache-time" content="15000">` configures the time to live in milliseconds for an entry in the InstantClick prefetch cache. When omitted, the default value is 10 seconds.