### PR TITLE
Rename "InstantClick" section

### DIFF
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -328,11 +328,11 @@ If the form submission is a GET request, you may render the directly rendered re
 
 Servers may also respond to form submissions with a [Turbo Streams](streams) message by sending the header `Content-Type: text/vnd.turbo-stream.html` followed by one or more `<turbo-stream>` elements in the response body. This lets you update multiple parts of the page without navigating.
 
-## InstantClick
+## Prefetching Links on Hover
 
-Turbo can also speed up perceived link navigation latency by automatically loading links on `mouseenter` or `touchstart` events, and before the user clicks the link. This usually leads to a speed bump of 500-800ms per click navigation.
+Turbo can also speed up perceived link navigation latency by automatically loading links on `mouseenter` events, and before the user clicks the link. This usually leads to a speed bump of 500-800ms per click navigation.
 
-InstantClick is enabled by default since Turbo v8, but you can disable it by adding this meta tag to your page:
+Prefetching links is enabled by default since Turbo v8, but you can disable it by adding this meta tag to your page:
 
 ```html
 <meta name="turbo-prefetch" content="false">


### PR DESCRIPTION
Turbo's link prefetching implementation is in no way affiliated with the pre-existing [InstantClick][] package. Turbo doesn't have a client-side dependency on the [instantclick package][], nor does it share any code with the [dieulot/instantclick][] repository.

With this in mind, this commit removes all mentions of "InstantClick" from the site and renames the heading to "Prefetching Links on Hover".

While editing that section, this commit also removes mention of handling `touchstart` events, since those events are not accounted for in the current implementation.

[InstantClick]: http://instantclick.io
[instantclick package]: https://www.npmjs.com/package/instantclick
[dieulot/instantclick]: https://github.com/dieulot/instantclick