### PR TITLE
Update lead paragraph about turbo streams

### DIFF
--- a/_source/handbook/05_streams.md
+++ b/_source/handbook/05_streams.md
@@ -5,7 +5,9 @@ description: "Turbo Streams deliver page changes over WebSocket, SSE or in respo
 
 # Come Alive with Turbo Streams
 
-Turbo Streams deliver page changes as fragments of HTML wrapped in self-executing `<turbo-stream>` elements. Each stream element specifies an action together with a target ID to declare what should happen to the HTML inside it. These elements are delivered by the server over a WebSocket, SSE or other transport to bring the application alive with updates made by other users or processes. A new email arriving in your <a href="http://itsnotatypo.com">imbox</a> is a great example.
+Turbo Streams deliver page changes as fragments of HTML wrapped in `<turbo-stream>` elements. Each stream element specifies an action together with a target ID to declare what should happen to the HTML inside it. These elements can be delivered to the browser synchronously as a classic HTTP response, or asynchronously over transports such as webSockets, SSE, etc, to bring the application alive with updates made by other users or processes.
+
+They can be used to surgically update the DOM after a user action such as removing an element from a list without reloading the whole page, or to implement real-time capabilities such as appending a new message to a live conversation as it is sent by a remote user.
 
 ## Stream Messages and Actions
 


### PR DESCRIPTION
Following this invitation from @dhh : https://twitter.com/dhh/status/1762272824864162101

I feel that the way turbo streams are presented is a bit misleading for newcomers, who will instantly associate it with websockets, when in reality the means of transportation is not the first thing you want to understand about it. I think the naming (streams vs something like action) is also a part of this confusion but this is another story.

Starting small, here is a suggestion to reword a bit the first paragraph, to display that they can be used in both sync and async scenarios, and to try and provide examples.

I'm not 100% happy about my sync example, as most of the use cases we already know for sync turbo streams can be replaced with morphing (although requiring more bandwidth as the whole page is sent)

Maybe we can find a different example that does not work in a morphing scenario, maybe something that includes some kind of state that is not present in the usual page load such as a toast message, etc.
