### PR TITLE
Describe criteria for link and form morphing

### DIFF
--- a/_source/handbook/03_page_refreshes.md
+++ b/_source/handbook/03_page_refreshes.md
@@ -11,6 +11,18 @@ A typical scenario for page refreshes is submitting a form and getting redirecte
 
 ${toc}
 
+## Page Refreshes
+
+A "page refresh" is a [application visit](/handbook/drive#application-visits) with a `"replace"` action to a URL with a whose [pathname](https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname) matches the current URL [path](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_URL#path_to_resource). Page refreshes can be initiated by driving the page with a link, or by [redirecting after a form submission](/handbook/drive#redirecting-after-a-form-submission). In either case, the elements must have a `[data-turbo-action="replace"]` attribute:
+
+```html
+<a href="/" data-turbo-action="replace">Page refresh link</a>
+
+<form action="/redirect_back" method="post" data-turbo-action="replace">
+  <button>Page refresh form</button>
+</form>
+```
+
 ## Morphing
 
 You can configure how Turbo handles page refresh with a `<meta name="turbo-refresh-method">` in the page's head.
@@ -22,13 +34,13 @@ You can configure how Turbo handles page refresh with a `<meta name="turbo-refre
 </head>
 ```
 
-The possible values are `morph` or `replace` (the default). When it is `morph,` when a page refresh happens, instead of replacing the page's `<body>,` Turbo will only update the DOM elements that have changed, keeping the rest untouched. This approach delivers better sensations because it keeps the screen state.
+The possible values are `morph` or `replace` (the default). When the `<meta>` element is omitted or its `content` attribute is `replace`, Turbo will [replace the page's `<body>` element](/handbook/drive#page-navigation-basics). When the `content` attribute is `morph`, Turbo will handle [page refreshes](#page-refreshes) by updating *only* the DOM elements that have changed. This approach delivers better sensations because it keeps the screen state like element focus.
 
 Under the hood, Turbo uses the fantastic [idiomorph library](https://github.com/bigskysoftware/idiomorph).
 
 ## Scroll preservation
 
-You can configure how Turbo handles scrolling with a `<meta name="turbo-refresh-scroll">` in the page's head.
+You can configure how Turbo handles scrolling when handling with a `<meta name="turbo-refresh-scroll">` in the page's head.
 
 ```html
 <head>
@@ -37,7 +49,7 @@ You can configure how Turbo handles scrolling with a `<meta name="turbo-refresh-
 </head>
 ```
 
-The possible values are `preserve` or `reset` (the default). When it is `preserve`, when a page refresh happens, Turbo will keep the page's vertical and horizontal scroll.
+The possible values are `preserve` or `reset` (the default). When the `<meta>` element is omitted or its `content` attribute is `reset`, Turbo will [reset the page's scroll position](/handbook/drive#application-visits). When the `content` attribute is `preserve`, Turbo will handle [page refreshes](#page-refreshes) by maintaining the page's vertical and horizontal scroll.
 
 ## Exclude sections from morphing
 
@@ -67,7 +79,7 @@ There is a new [turbo stream action](/handbook/streams.html) called `refresh` th
 <turbo-stream action="refresh"></turbo-stream>
 ```
 
-Server-side frameworks can leverage these streams to offer a simple but powerful broadcasting model: the server broadcasts a single general signal, and pages smoothly refresh with morphing. 
+Server-side frameworks can leverage these streams to offer a simple but powerful broadcasting model: the server broadcasts a single general signal, and pages smoothly refresh with morphing.
 
 You can see how the  [`turbo-rails`](https://github.com/hotwired/turbo-rails) gem does it for Rails:
 


### PR DESCRIPTION
Expand upon the Page Refresh sections explaining how to morph and preserve scrolling.

Page Refreshes
---

A "page refresh" is a [application visit](/handbook/drive#application-visits) with a `"replace"` action to a URL with a whose [pathname](https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname) matches the current URL [path](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_URL#path_to_resource). Page refreshes can be initiated by driving the page with a link, or by [redirecting after a form submission](/handbook/drive#redirecting-after-a-form-submission). In either case, the elements must have a `[data-turbo-action="replace"]` attribute:

```html
<a href="/" data-turbo-action="replace">Page refresh link</a>

<form action="/redirect_back" method="post" data-turbo-action="replace">
  <button>Page refresh form</button>
</form>
```