### PR TITLE
Add section about changed behavior for links and forms

### DIFF
--- a/_source/reference/drive.md
+++ b/_source/reference/drive.md
@@ -6,6 +6,19 @@ description: "A reference of everything you can do with Turbo Drive."
 
 # Drive
 
+## Changed link and form behavior
+Turbo Drive intercepts the following events:
+
+* `"click"` on link elements
+* `"submit"` on form elements
+
+Then does the following:
+1. Prevents the default behavior
+2. Updates the browser's URL, using the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
+3. Makes an AJAX request to the appropriate URL
+4. Replaces the browser's `<body>` element with the response's `<body>` element, and merges the contents of their `<head>` elements if they changed
+5. If the URL includes `#hash` location, attempts to scroll to the element with that `id`
+
 ## Turbo.visit
 
 ```js

--- a/_source/reference/drive.md
+++ b/_source/reference/drive.md
@@ -7,10 +7,10 @@ description: "A reference of everything you can do with Turbo Drive."
 # Drive
 
 ## Changed link and form behavior
-Turbo Drive intercepts the following events:
+Turbo Drive intercepts the following:
 
-* `"click"` on link elements
-* `"submit"` on form elements
+* `"click"` event on link elements
+* `"submit"` event on form elements
 
 Then does the following:
 1. Prevents the default behavior


### PR DESCRIPTION
These behavior changes are foundational to how Turbo Drive works, so I was expecting them to be in the reference section, but they weren't.

I tried to follow the succinct style of the Reference section but feel free to tweak or suggest any changes.