### PR TITLE
setConfirmMethod can return a Promise

### DIFF
--- a/_source/reference/drive.md
+++ b/_source/reference/drive.md
@@ -52,7 +52,9 @@ Note that this method has no effect when used with the iOS or Android adapters.
 Turbo.setConfirmMethod(confirmMethod)
 ```
 
-Sets the method that is called by links decorated with [`data-turbo-confirm`](/handbook/drive#requiring-confirmation-for-a-visit). The default is the browser's built in `confirm`. The method should return `true` if the visit can proceed.
+Sets the method that is called by links decorated with [`data-turbo-confirm`](/handbook/drive#requiring-confirmation-for-a-visit). The default is the browser's built in `confirm`.
+
+The `confirmMethod` can return a synchronous value or a Promise. Set the result to `true` to allow the visit to proceed.
 
 ## Turbo.session.drive
 


### PR DESCRIPTION
According to the [source](https://github.com/hotwired/turbo/blob/00527e50ed1a4298ce52f968f2a007f6cfd30776/src/core/drive/form_submission.js#L81), the `confirmMethod` for `Turbo.setConfirmMethod` can return a Promise. This makes it much easier to create a custom component to render instead of the default `window.confirm`.

The docs don't mention this, so this PR adds a section to this effect.