### PR TITLE
Update 08_installing.md

### DIFF
--- a/_source/handbook/08_installing.md
+++ b/_source/handbook/08_installing.md
@@ -13,10 +13,18 @@ You can float on the latest release of Turbo using a CDN bundler like Skypack. S
 
 ## As An npm Package
 
-You can install Turbo from npm via the `npm` or `yarn` packaging tools. Then require or import that in your code:
+You can install Turbo from npm via the `npm` or `yarn` packaging tools. 
+
+If you using any Turbo functions such as `Turbo.visit()` import the `Turbo` functions into your code:
 
 ```javascript
 import * as Turbo from "@hotwired/turbo"
+```
+
+If you're *not* using any Turbo functions such as `Turbo.visit()` import the library. This avoids issues with tree-shaking and unused variables in some bundlers. See [Import a module for its side effects only](https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/import#import_a_module_for_its_side_effects_only) on MDN.
+
+```javascript
+import "@hotwired/turbo";
 ```
 
 ## In a Ruby on Rails application


### PR DESCRIPTION
Add alternative side-affects only import.

When installing Turbo with a tree-shaking bundler eg Vite / Rollup the import will be removed if not referenced in the file.

Additionally ESLint throws an error: 

![image](https://github.com/hotwired/turbo-site/assets/25124/59dc3548-8258-4f6e-880c-3ee4a3f7dd0f)

Alternative ways around this are to:

Export Turbo at the end of the import eg `export {Turbo }`