### PR TITLE
Re-structure turbo-stream[action=morph] support

### DIFF
--- a/_source/handbook/05_streams.md
+++ b/_source/handbook/05_streams.md
@@ -38,6 +38,13 @@ A Turbo Streams message is a fragment of HTML consisting of `<turbo-stream>` ele
   </template>
 </turbo-stream>
 
+<turbo-stream action="replace" method="morph" target="current_step">
+  <template>
+    <!-- The contents of this template will replace the element with ID "current_step" via morph. -->
+    <li>New item</li>
+  </template>
+</turbo-stream>
+
 <turbo-stream action="update" target="unread_count">
   <template>
     <!-- The contents of this template will replace the
@@ -49,6 +56,13 @@ A Turbo Streams message is a fragment of HTML consisting of `<turbo-stream>` ele
     that action would necessitate the rebuilding of
     handlers. -->
     1
+  </template>
+</turbo-stream>
+
+<turbo-stream action="update" method="morph" target="current_step">
+  <template>
+    <!-- The contents of this template will replace the children of the element with ID "current_step" via morph. -->
+    <li>New item</li>
   </template>
 </turbo-stream>
 
@@ -69,22 +83,6 @@ A Turbo Streams message is a fragment of HTML consisting of `<turbo-stream>` ele
   <template>
     <!-- The contents of this template will be added after the
     the element with ID "current_step". -->
-    <li>New item</li>
-  </template>
-</turbo-stream>
-
-<turbo-stream action="morph" target="current_step">
-  <template>
-    <!-- The contents of this template will replace the 
-    element with ID "current_step" via morph. -->
-    <li>New item</li>
-  </template>
-</turbo-stream>
-
-<turbo-stream action="morph" target="current_step" children-only>
-  <template>
-    <!-- The contents of this template will replace the 
-    children of the element with ID "current_step" via morph. -->
     <li>New item</li>
   </template>
 </turbo-stream>

--- a/_source/reference/streams.md
+++ b/_source/reference/streams.md
@@ -46,6 +46,16 @@ Replaces the element designated by the target dom id.
 </turbo-stream>
 ```
 
+The `[method="morph"]` attribute can be added to the `turbo-stream` element to replace the element designated by the target dom id via morph.
+
+```html
+<turbo-stream action="replace" method="morph" target="dom_id">
+  <template>
+    Content to replace the element.
+  </template>
+</turbo-stream>
+```
+
 ### Update
 
 Updates the content within the template tag to the container designated by the target dom id.
@@ -54,6 +64,16 @@ Updates the content within the template tag to the container designated by the t
 <turbo-stream action="update" target="dom_id">
   <template>
     Content to update to container designated with the dom_id.
+  </template>
+</turbo-stream>
+```
+
+The `[method="morph"]` attribute can be added to the `turbo-stream` element to morph only the children of the element designated by the target dom id.
+
+```html
+<turbo-stream action="update" method="morph" target="dom_id">
+  <template>
+    Content to replace the element.
   </template>
 </turbo-stream>
 ```
@@ -87,28 +107,6 @@ Inserts the content within the template tag after the element designated by the 
 <turbo-stream action="after" target="dom_id">
   <template>
     Content to place after the element designated with the dom_id.
-  </template>
-</turbo-stream>
-```
-
-### Morph
-
-Replaces the element designated by the target dom id via morph.
-
-```html
-<turbo-stream action="morph" target="dom_id">
-  <template>
-    Content to replace the element.
-  </template>
-</turbo-stream>
-```
-
-The `children-only` attribute can be added to the `turbo-stream` element to morph only the children of the element designated by the target dom id.
-
-```html
-<turbo-stream action="morph" target="dom_id" children-only>
-  <template>
-    Content to replace the element.
   </template>
 </turbo-stream>
 ```


### PR DESCRIPTION
Related to [hotwired/turbo#1240][]

Since the `<turbo-stream action="morph">` hasn't yet been part of a release, there's an opportunity to rename it without being considerate of backwards compatibility.

As an alternative to introduce a new Stream Action, this commit changes existing actions to be more flexible.

For example, the `<turbo-stream method="morph">` element behaves like a specialized version of a `<turbo-stream method="replace">`, since it operates on the target element's `outerHTML` property.

Similarly, the `<turbo-stream method="morph" children-only>` element behaves like a specialized version of a `<turbo-stream method="update">`, since it operates on the target element's `innerHTML` property.

```diff
-<turbo-stream action="morph">
+<turbo-stream action="replace" method="morph">
   <template>Replace me with morphing</template>
 </turbo-stream>

-<turbo-stream action="morph" children-only>
+<turbo-stream action="update" method="morph">
   <template>Update me with morphing</template>
 </turbo-stream>
```

[hotwired/turbo#1240]: https://github.com/hotwired/turbo/pull/1240