### PR TITLE
Fix non-working example of data-turbo-confirm without data-turbo-method

### DIFF
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -143,7 +143,7 @@ You should also consider that for accessibility reasons, it's better to use actu
 Decorate links with `data-turbo-confirm`, and confirmation will be required for a visit to proceed.
 
 ```html
-<a href="/articles" data-turbo-confirm="Do you want to leave this page?">Back to articles</a>
+<a href="/articles" data-turbo-method="get" data-turbo-confirm="Do you want to leave this page?">Back to articles</a>
 <a href="/articles/54" data-turbo-method="delete" data-turbo-confirm="Are you sure you want to delete the article?">Delete the article</a>
 ```
 


### PR DESCRIPTION
Until https://github.com/hotwired/turbo/pull/874 or https://github.com/hotwired/turbo/pull/1266 resolve https://github.com/hotwired/turbo/issues/1264 and  https://github.com/hotwired/turbo/issues/943, the doc site is wrong and I keep wasting time double-checking it, only for its wrongness to result in me wasting more time debugging Turbo's source code.