### PR TITLE
Add docs on `download` attribute

### DIFF
--- a/_source/reference/attributes.md
+++ b/_source/reference/attributes.md
@@ -24,7 +24,8 @@ The following data attributes can be applied to elements to customize Turbo's be
 * `data-turbo-stream` specifies that a link or form can accept a Turbo Streams response. Turbo [automatically requests stream responses](/handbook/streams#streaming-from-http-responses) for form submissions with non-`GET` methods; `data-turbo-stream` allows Turbo Streams to be used with `GET` requests as well.
 * `data-turbo-confirm` presents a confirm dialog with the given value. Can be used on `form` elements or links with `data-turbo-method`.
 * `data-turbo-submits-with` specifies text to display when submitting a form. Can be used on `input` or `button` elements. While the form is submitting the text of the element will show the value of `data-turbo-submits-with`. After the submission, the original text will be restored. Useful for giving user feedback by showing a message like "Saving..." while an operation is in progress.
-* `data-turbo-prefetch="false"` disables [prefetching links on hover](/handbook/drive#prefetching-links-on-hover) 
+* `data-turbo-prefetch="false"` disables [prefetching links on hover](/handbook/drive#prefetching-links-on-hover)
+* `download` opts out of Turbo since the link is for downloading files and not navigation.
 
 ## Automatically Added Attributes
 


### PR DESCRIPTION
Hey!

I wasn't sure if this was the correct place to put this but I couldn't find any other documentation on this functionality.

Relevant code path: https://github.com/hotwired/turbo-rails/blob/9b17a3be3705786d72c3ae77fde5a9b3006555d7/app/assets/javascripts/turbo.js#L500