### PR TITLE
Remove "By default" ambiguity

### DIFF
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -286,7 +286,7 @@ This setting may be useful as a workaround for third-party JavaScript libraries 
 
 ## Setting a Root Location
 
-By default, Turbo Drive only loads URLs with the same origin—i.e. the same protocol, domain name, and port—as the current document. A visit to any other URL falls back to a full page load.
+Turbo Drive only loads URLs with the same origin—i.e. the same protocol, domain name, and port—as the current document. A visit to any other URL falls back to a full page load.
 
 In some cases, you may want to further scope Turbo Drive to a path on the same origin. For example, if your Turbo Drive application lives at `/app`, and the non-Turbo Drive help site lives at `/help`, links from the app to the help site shouldn’t use Turbo Drive.
 


### PR DESCRIPTION
> By default, Turbo Drive only loads URLs with the same origin

"By default" suggests it's a default and that you can potentially change the behavior. However that's not the case.