### PR TITLE
Correct `mutationType` value typos

### DIFF
--- a/_source/reference/events.md
+++ b/_source/reference/events.md
@@ -127,7 +127,7 @@ Fires before Turbo morphs an element's attributes. The [event.target][] referenc
 | `event.detail` property   | Type                      | Description
 |---------------------------|---------------------------|------------
 | `attributeName`           | `string`                  | the name of the attribute to be mutated
-| `mutationType`            | `"updated" \| "removed"`  | how the attribute will be mutated
+| `mutationType`            | `"update" \| "remove"`    | how the attribute will be mutated
 
 ### `turbo:morph-element`
 


### PR DESCRIPTION
The potential `mutationType` values are [update][] and [remove][], not `updated` and `removed`.

[update]: https://github.com/bigskysoftware/idiomorph/blob/v0.3.0/src/idiomorph.js#L284
[remove]: https://github.com/bigskysoftware/idiomorph/blob/v0.3.0/src/idiomorph.js#L294