### PR TITLE
Correct event.detail properties of `turbo:submit-end`

### DIFF
--- a/_source/reference/events.md
+++ b/_source/reference/events.md
@@ -155,12 +155,12 @@ Fires during a form submission. Access the [FormSubmission][] object with `event
 
 Fires after the form submission-initiated network request completes. Access the [FormSubmission][] object with `event.detail.formSubmission` along with the properties included within `event.detail`.
 
-| `event.detail` property   | Type                          | Description
-|---------------------------|-------------------------------|------------
-| `formSubmission`          | [FormSubmission][]            | the `<form>` element submission
-| `success`                 | `boolean`                     | a `boolean` representing the request's success
-| `fetchResponse`           | [FetchResponse][] \| `null`   | present when `success: true`, `null` when `success: false`
-| `error`                   | [Error][] or `null`           | `null` when `success: true`, present when `success: false`
+| `event.detail` property   | Type                             | Description
+|---------------------------|----------------------------------|------------
+| `formSubmission`          | [FormSubmission][]               | The `<form>` element submission.
+| `success`                 | `boolean`                        | A `boolean` representing the request's success.
+| `fetchResponse`           | [FetchResponse][] \| `undefined` | Present when a response is received, even if `success: false`. Undefined if the request errored before a response was received.
+| `error`                   | [Error][] \| `undefined`         | Undefined unless an actual fetch error occurs (e.g., network issues).
 
 [Error]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors
 [FormSubmission]: /reference/drive#formsubmission


### PR DESCRIPTION
**Clarified fetchResponse behavior**: Now reflects that fetchResponse can be present even when success: false (e.g., for 4xx or 5xx server errors), and it is only undefined when the fetch itself fails.

**Updated error property description**: Specifies that error is undefined by default and is only set when a fetch error occurs (e.g., network issues)