### PR TITLE
Clarify `data-turbo-method` is needed for `data-turbo-confirm` on links

### DIFF
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -140,10 +140,10 @@ You should also consider that for accessibility reasons, it's better to use actu
 
 ## Requiring Confirmation for a Visit
 
-Decorate links with `data-turbo-confirm`, and confirmation will be required for a visit to proceed.
+Decorate links with both `data-turbo-confirm` and `data-turbo-method`, and confirmation will be required for a visit to proceed.
 
 ```html
-<a href="/articles" data-turbo-confirm="Do you want to leave this page?">Back to articles</a>
+<a href="/articles" data-turbo-method="get" data-turbo-confirm="Do you want to leave this page?">Back to articles</a>
 <a href="/articles/54" data-turbo-method="delete" data-turbo-confirm="Are you sure you want to delete the article?">Delete the article</a>
 ```
 


### PR DESCRIPTION
The example about `data-turbo-confirm` on links doesn't make clear that `data-turbo-method` is also needed. 

The [Attributes section](https://turbo.hotwired.dev/reference/attributes) already mentions that, but this detail in particular is missing from general Turbo Drive guide.