### PR TITLE
Update the documentation for configuration methods to match the code

### DIFF
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -147,7 +147,7 @@ Decorate links with both `data-turbo-confirm` and `data-turbo-method`, and confi
 <a href="/articles/54" data-turbo-method="delete" data-turbo-confirm="Are you sure you want to delete the article?">Delete the article</a>
 ```
 
-Use `Turbo.setConfirmMethod` to change the method that gets called for confirmation. The default is the browser's built in `confirm`.
+Use `Turbo.config.forms.confirm = confirmMethod` to change the method that gets called for confirmation. The default is the browser's built in `confirm`.
 
 
 ## Disabling Turbo Drive on Specific Links or Forms

--- a/_source/reference/drive.md
+++ b/_source/reference/drive.md
@@ -36,23 +36,27 @@ Removes all entries from the Turbo Drive page cache. Call this when state has ch
 
 **Note:** This function was previously exposed as `Turbo.clearCache()`. The top-level function was deprecated in favor of the new `Turbo.cache.clear()` function.
 
-## Turbo.setProgressBarDelay
+## Turbo.config.drive.progressBarDelay
 
 ```js
-Turbo.setProgressBarDelay(delayInMilliseconds)
+Turbo.config.drive.progressBarDelay = delayInMilliseconds
 ```
 
 Sets the delay after which the [progress bar](/handbook/drive#displaying-progress) will appear during navigation, in milliseconds. The progress bar appears after 500ms by default.
 
 Note that this method has no effect when used with the iOS or Android adapters.
 
-## Turbo.setConfirmMethod
+**Note:** This function was previously exposed as `Turbo.setProgressBarDelay` function. The top-level function was deprecated in favor of the new `Turbo.config.drive.progressBarDelay = delayInMilliseconds` syntax.
+
+## Turbo.config.forms.confirm
 
 ```js
-Turbo.setConfirmMethod(confirmMethod)
+Turbo.config.forms.confirm = confirmMethod
 ```
 
-Sets the method that is called by links decorated with [`data-turbo-confirm`](/handbook/drive#requiring-confirmation-for-a-visit). The default is the browser's built in `confirm`. The method should return `true` if the visit can proceed.
+Sets the method that is called by links decorated with [`data-turbo-confirm`](/handbook/drive#requiring-confirmation-for-a-visit). The default is the browser's built in `confirm`. The method should return a `Promise` object that resolves to true or false, depending on whether the visit should proceed.
+
+**Note:** This function was previously exposed as `Turbo.setConfirmMethod` function. The top-level function was deprecated in favor of the new `Turbo.config.forms.confirm = confirmMethod` syntax.
 
 ## Turbo.session.drive
 


### PR DESCRIPTION
The documentation was behind the latest code version. This makes updates to bring the relevant methods in line with the current state of the code.