### PR TITLE
Fix the native section on the turbo handhook still mentioning Turbo Native instead of Hotwire Native

### DIFF
--- a/_source/handbook/06_native.md
+++ b/_source/handbook/06_native.md
@@ -1,12 +1,12 @@
 ---
 permalink: /handbook/native.html
-description: "Turbo Native lets your majestic monolith form the center of your native iOS and Android apps, with seamless transitions between web and native sections."
+description: "Hotwire Native lets your majestic monolith form the center of your native iOS and Android apps, with seamless transitions between web and native sections."
 ---
 
 # Go Native on iOS & Android
 
-Turbo Native for iOS provides the tooling to wrap your Turbo-enabled web app in a native iOS shell. It manages a single WKWebView instance across multiple view controllers, giving you native navigation UI with all the client-side performance benefits of Turbo. See <a href="https://github.com/hotwired/turbo-ios">Turbo Native: iOS</a> for more details.
+Hotwire Native for iOS provides the tooling to wrap your Turbo-enabled web app in a native iOS shell. It manages a single WKWebView instance across multiple view controllers, giving you native navigation UI with all the client-side performance benefits of Turbo. See <a href="https://github.com/hotwired/hotwire-native-ios/">Hotwire Native: iOS</a> for more details.
 
-Turbo Native for Android provides the same kind of tooling, managing a single WebView instance across multiple Fragment destinations. See <a href="https://github.com/hotwired/turbo-android">Turbo Native: Android</a> for more details.
+Hotwire Native for Android provides the same kind of tooling, managing a single WebView instance across multiple Fragment destinations. See <a href="https://github.com/hotwired/hotwire-native-android/">Hotwire Native: Android</a> for more details.
 
-The best way to see what's possible with the native adapters is to setup the demo native application. We have one [for iOS](https://github.com/hotwired/turbo-ios/blob/main/Demo/README.md) and [for Android](https://github.com/hotwired/turbo-android/blob/main/demo/README.md). You can open the code in your native environments and follow along to explore all the features.
+The best way to see what's possible with the native adapters is to setup the demo native application. We have one [for iOS](https://native.hotwired.dev/ios/getting-started) and [for Android](https://native.hotwired.dev/android/getting-started). You can open the code in your native environments and follow along to explore all the features.


### PR DESCRIPTION
### Changed

- Updates the native section of the Turbo handbook to mention Hotwire Native instead of Turbo Native