### PR TITLE
Allow line breaks on code blocks

### DIFF
--- a/_source/_assets/css/base/_elements.scss
+++ b/_source/_assets/css/base/_elements.scss
@@ -200,6 +200,7 @@ pre {
 code {
   padding: 0.125em;
   word-wrap: break-word;
+  white-space: break-spaces;
 }
 
 pre > code {


### PR DESCRIPTION
So we can read the tables better with code blocks.

Before

![image](https://github.com/user-attachments/assets/7a1bae5c-28a1-486f-ab1e-234f859460cf)


After

![image](https://github.com/user-attachments/assets/ff30ea36-bc31-43a9-ab4e-52357abeb9d1)
