### PR TITLE
Fix broken markdown links in Turbo Drive Reference tables

### DIFF
--- a/_source/reference/drive.md
+++ b/_source/reference/drive.md
@@ -110,7 +110,7 @@ Turbo dispatches a variety of [events while making HTTP requests](/reference/eve
 [Response.ok]: https://developer.mozilla.org/en-US/docs/Web/API/Response/ok
 [Response.redirected]: https://developer.mozilla.org/en-US/docs/Web/API/Response/redirected
 [Response.status]: https://developer.mozilla.org/en-US/docs/Web/API/Response/status
-[Response.text]: https://developer.mozilla.org/en-US/docs/Web/API/Response/text
+[Response.text()]: https://developer.mozilla.org/en-US/docs/Web/API/Response/text
 [Content-Type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
 
 ## `FormSubmission`
@@ -134,3 +134,6 @@ Turbo dispatches a variety of [events while submitting forms](/reference/events#
 [HTMLFormElement]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement
 [URLSearchParams]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
 [URL]: https://developer.mozilla.org/en-US/docs/Web/API/URL
+[HTMLButtonElement]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement
+[HTMLInputElement]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement
+[Request]: https://developer.mozilla.org/en-US/docs/Web/API/Request


### PR DESCRIPTION
Because:
- Some of the link URLs were missing:

<img width="943" alt="Screenshot 2025-04-19 at 15 37 05" src="https://github.com/user-attachments/assets/609316b4-d325-4912-a44b-42736b0c9763" />

<img width="1032" alt="Screenshot 2025-04-19 at 15 37 30" src="https://github.com/user-attachments/assets/633da5e1-b8be-462e-97f7-7ca056989b51" />


