### PR TITLE
Replaces `disconnected` for `disconnects` on Turbo Drive documentation

### DIFF
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -267,7 +267,7 @@ Rendering a `<link>` or `<style>` element with `[data-turbo-track="dynamic"]` in
 </head>
 ```
 
-Note that rendering `<script>` elements with `[data-turbo-track="dynamic"]` might have unintended side-effects. When `<script>` disconnected from the document, the JavaScript context doesn't change, nor is the element's already evaluated JavaScript code unloaded or changed in any way.
+Note that rendering `<script>` elements with `[data-turbo-track="dynamic"]` might have unintended side-effects. When `<script>` disconnects from the document, the JavaScript context doesn't change, nor is the element's already evaluated JavaScript code unloaded or changed in any way.
 
 ## Ensuring Specific Pages Trigger a Full Reload
 


### PR DESCRIPTION
Fixes a small typo on the Turbo Drive [documentation](https://turbo.hotwired.dev/handbook/drive#reloading-when-assets-change:~:text=Note%20that%20rendering%20%3Cscript%3E%20elements%20with%20%5Bdata%2Dturbo%2Dtrack%3D%22dynamic%22%5D%20might%20have%20unintended%20side%2Deffects.%20When%20%3Cscript%3E%20disconnected%20from%20the%20document%2C%20the%20JavaScript%20context%20doesn%E2%80%99t%20change%2C%20nor%20is%20the%20element%E2%80%99s%20already%20evaluated%20JavaScript%20code%20unloaded%20or%20changed%20in%20any%20way.).