### PR TITLE
Document `refresh` action attributes `method=` and `scroll=`

### DIFF
--- a/_source/handbook/03_page_refreshes.md
+++ b/_source/handbook/03_page_refreshes.md
@@ -66,6 +66,14 @@ There is a new [turbo stream action](/handbook/streams.html) called `refresh` th
 <turbo-stream action="refresh"></turbo-stream>
 ```
 
+Refresh behavior can be specified using the `method` and `scroll` attributes:
+
+```html
+<turbo-stream action="refresh" method="morph" scroll="preserve"></turbo-stream>
+```
+
+The `method` attribute can be `morph` or `replace`, and the `scroll` attribute can be `preserve` or `reset`.
+
 Server-side frameworks can leverage these streams to offer a simple but powerful broadcasting model: the server broadcasts a single general signal, and pages smoothly refresh with morphing. 
 
 You can see how the  [`turbo-rails`](https://github.com/hotwired/turbo-rails) gem does it for Rails:

--- a/_source/reference/streams.md
+++ b/_source/reference/streams.md
@@ -113,8 +113,7 @@ Inserts the content within the template tag after the element designated by the 
 
 ### Refresh
 
-Initiates a [Page Refresh](/handbook/page_refreshes) to render new content with
-morphing.
+Initiates a [Page Refresh](/handbook/page_refreshes) to render new content.
 
 ```html
 <!-- without `[request-id]` -->
@@ -122,6 +121,9 @@ morphing.
 
 <!-- debounced with `[request-id]` -->
 <turbo-stream action="refresh" request-id="abcd-1234"></turbo-stream>
+
+<!-- refresh behavior with `[method]` and `[scroll]` -->
+<turbo-stream action="refresh" method="morph" scroll="preserve"></turbo-stream>
 ```
 
 ## Targeting Multiple Elements


### PR DESCRIPTION
This PR adds brief documention for stream actions attributes, specifically `method=` and `scroll=`.

These arguments are passed down to the turbo visit and can control refresh behavior to override page meta tag defined refresh behavior. This behavior is really useful when a complex page requires multiple refresh methods depending on the action taken.

https://github.com/hotwired/turbo/blob/4481af6b6d7483363a44ee9f4af2e0f879c83b3c/src/core/session.js#L111