### PR TITLE
Update meta tag name and value for view transition

### DIFF
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -191,7 +191,7 @@ In [browsers that support](https://caniuse.com/?search=View%20Transition%20API) 
 Turbo triggers a view transition when both the current and the next page have this meta tag:
 
 ```
-<meta name="view-transition" content="same-origin" />
+<meta name="turbo-view-transition" content="true" />
 ```
 
 Turbo also adds a `data-turbo-visit-direction` attribute to the `<html>` element to indicate the direction of the transition. The attribute can have one of the following values:

--- a/_source/reference/attributes.md
+++ b/_source/reference/attributes.md
@@ -47,7 +47,7 @@ The following `meta` elements, added to the `head`, can be used to customize cac
 * `<meta name="turbo-cache-control">` to [opt out of caching](/handbook/building#opting-out-of-caching).
 * `<meta name="turbo-visit-control" content="reload">` will perform a full page reload whenever Turbo navigates to the page, including when the request originates from a `<turbo-frame>`.
 * `<meta name="turbo-root">` to [scope Turbo Drive to a particular root location](/handbook/drive#setting-a-root-location).
-* `<meta name="view-transition" content="same-origin">` to trigger view transitions on browsers that support the [View Transition API](https://caniuse.com/view-transitions).
+* `<meta name="turbo-view-transition" content="true">` to trigger view transitions on browsers that support the [View Transition API](https://caniuse.com/view-transitions).
 * `<meta name="turbo-refresh-method" content="morph">` will configure [page refreshes with morphing](/handbook/page_refreshes.html).
 * `<meta name="turbo-refresh-scroll" content="preserve">` will enable [scroll preservation during page refreshes](/handbook/page_refreshes.html).
 * `<meta name="turbo-prefetch" content="false">` will disable [prefetching links on hover](/handbook/drive#prefetching-links-on-hover).


### PR DESCRIPTION
The docs still mention the deprecated meta tag for enabling view transition, see https://github.com/hotwired/turbo/pull/1380

This PR switches the examples to use the new name and value