### PR TITLE
Document frames-in-tables limitation and workarounds

### DIFF
--- a/_source/handbook/04_frames.md
+++ b/_source/handbook/04_frames.md
@@ -245,6 +245,17 @@ If your application needs to handle missing frames in some other way, you can in
 [meta]: /reference/attributes#meta-tags
 [events]: /reference/events
 
+## Frames and HTML Tables
+
+The HTML parser restricts which elements may appear inside a `<table>`. A `<turbo-frame>` wrapping a `<tr>` or `<tbody>` is moved out of the table during parsing — before Turbo or any script runs — which breaks both the table's layout and the frame's behavior. This is a constraint of HTML itself, not of Turbo, and the customized built-in syntax (`<tr is="turbo-frame">`) is not a way out: WebKit does not implement the `is` attribute, so it would not work in Safari or in Turbo Native iOS apps.
+
+To update table content with Turbo, use one of these approaches instead:
+
+* **Place frames inside a cell.** `<td><turbo-frame id="…">` is valid HTML, so cell-level lazy loading and scoped navigation work as usual.
+* **Target rows with Turbo Streams.** A `<turbo-stream>` action can target a `<tr id="…">` or `<tbody id="…">` directly to append, replace, or remove rows in response to a form submission.
+* **Use page refreshes with morphing.** Rows are updated in place without any structural changes to the markup.
+* **Render the table with CSS.** If a row really must behave as a frame, build the table from `<div>` elements using CSS grid or `display: table-row`, together with the ARIA `table`, `row`, and `cell` roles, and wrap those elements in frames.
+
 ## Anti-Forgery Support (CSRF)
 
 Turbo provides [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) protection by checking the DOM for the existence of a `<meta>` tag with a `name` value of either `csrf-param` or `csrf-token`. For example:

--- a/_source/handbook/04_frames.md
+++ b/_source/handbook/04_frames.md
@@ -252,7 +252,7 @@ The HTML parser restricts which elements may appear inside a `<table>`. A `<turb
 To update table content with Turbo, use one of these approaches instead:
 
 * **Place frames inside a cell.** `<td><turbo-frame id="…">` is valid HTML, so cell-level lazy loading and scoped navigation work as usual.
-* **Target rows with Turbo Streams.** A `<turbo-stream>` action can target a `<tr id="…">` or `<tbody id="…">` directly to append, replace, or remove rows in response to a form submission.
+* **Target rows with Turbo Streams.** A `<turbo-stream>` action can target a `<tr id="…">` or `<tbody id="…">` directly to append, replace, or remove rows in response to a form submission. If you're using Turbo Rails, give the row its id with the [`dom_id`](https://api.rubyonrails.org/classes/ActionView/RecordIdentifier.html) helper — `<tr id="<%= dom_id(message) %>">` — which produces the same id `turbo_frame_tag(message)` would, so stream helpers like `turbo_stream.replace(message)` find the row automatically.
 * **Use page refreshes with morphing.** Rows are updated in place without any structural changes to the markup.
 * **Render the table with CSS.** If a row really must behave as a frame, build the table from `<div>` elements using CSS grid or `display: table-row`, together with the ARIA `table`, `row`, and `cell` roles, and wrap those elements in frames.
 


### PR DESCRIPTION
`<turbo-frame>` can't wrap `<tr>` or `<tbody>`: the HTML parser only allows certain children inside `<table>`, so a frame wrapping a row gets foster-parented out of the table before any script runs, breaking both the table layout and the frame. People run into this regularly (hotwired/turbo#547, hotwired/turbo#48), but it's a constraint of HTML rather than a bug in Turbo, so the docs seem like the right place to address it.

The `<tr is="turbo-frame">` route proposed in hotwired/turbo#547 (and attempted in hotwired/turbo#599) doesn't get around it either: WebKit has declined to implement the `is` attribute, so it would never work in Safari or Turbo Native iOS without a third-party polyfill. I wrote up the details in https://github.com/hotwired/turbo/issues/547#issuecomment-5119107282.

This adds a "Frames and HTML Tables" section to the frames handbook covering the constraint and the approaches that do work everywhere: frames inside `<td>`, Turbo Streams targeting rows, morphing page refreshes, and CSS-built tables.
